### PR TITLE
Cost table: add AQT IBEX via AWS Braket

### DIFF
--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -73,16 +73,23 @@ Plot.plot({
 10 circuits × 100 shots. Pricing as of April 2026.
 
 ```js
-Inputs.table(summary.map(p => ({
-  platform: p.platform === "rigetti" ? "Rigetti Ankaa-3" :
-            p.platform === "aqt"     ? "AQT IBEX" :
-                                       "IonQ Aria-1",
-  access: p.platform === "rigetti" ? "AWS Braket" :
-          p.platform === "aqt"     ? "qiskit-aqt-provider (direct)" :
-                                     "AWS Braket (historical)",
-  cost_per_run: p.cost_per_run_usd,
-  annual_52: p.cost_per_run_usd * 52,
-})), {
+const costRows = [
+  ...summary.map(p => ({
+    platform: p.platform === "rigetti" ? "Rigetti Ankaa-3" :
+              p.platform === "aqt"     ? "AQT IBEX" :
+                                         "IonQ Aria-1",
+    access: p.platform === "rigetti" ? "AWS Braket" :
+            p.platform === "aqt"     ? "qiskit-aqt-provider (direct)" :
+                                       "AWS Braket (historical)",
+    cost_per_run: p.cost_per_run_usd,
+    annual_52: p.cost_per_run_usd * 52,
+  })),
+  {platform: "AQT IBEX (alt)", access: "AWS Braket", cost_per_run: 26.50, annual_52: 26.50 * 52},
+];
+```
+
+```js
+Inputs.table(costRows, {
   columns: ["platform", "access", "cost_per_run", "annual_52"],
   header: {platform: "Platform", access: "Access", cost_per_run: "Per run", annual_52: "Annual (52×)"},
   format: {
@@ -92,7 +99,7 @@ Inputs.table(summary.map(p => ({
 })
 ```
 
-*AQT pricing from quotation Q2511001 (Nov 2025), converted at EUR/USD ≈ 1.09. IonQ figure is historical (Aria-1 at $0.03/shot); current Forte would be ~$83/run.*
+*AQT pricing from quotation Q2511001 (Nov 2025), converted at EUR/USD ≈ 1.09. "AQT IBEX (alt)" is the AWS Braket-managed access path — within ~5% of direct, slightly more expensive. IonQ figure is historical (Aria-1 at $0.03/shot); current Forte would be ~$83/run.*
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a row for AQT IBEX accessed via AWS Braket to the cost comparison table on the overview page.

- Direct (qiskit-aqt-provider): **$25.07/run** — what we currently use
- Via Braket (eu-north-1): **$26.50/run** — ~5% more expensive, useful reference

The Braket row is hardcoded as a static entry (not wired through the summary loader) since it's a cost reference, not a platform we actually run.

Pricing source: `scripts/cost_estimate.py` (verified 2026-04-04).