### PR TITLE
feat: IonQ Forte-1 via direct REST API (monthly, 10 circuits)

### DIFF
--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           BRAKET_RESULTS_BUCKET: ${{ vars.BRAKET_RESULTS_BUCKET }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
+          IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
         run: uv run python scripts/collect_results.py
 
       - name: Commit results

--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Collect results
         if: steps.check.outputs.pending_count != '0'
         env:
-          BRAKET_RESULTS_BUCKET: ${{ vars.BRAKET_RESULTS_BUCKET }}
+          BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
           IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
         run: uv run python scripts/collect_results.py

--- a/.github/workflows/submit-benchmark-ionq-braket.yml
+++ b/.github/workflows/submit-benchmark-ionq-braket.yml
@@ -1,0 +1,60 @@
+name: Submit IonQ Braket Benchmark
+
+on:
+  schedule:
+    # 15th of every month at 10:30 UTC.
+    # Offset from ionq_direct (1st of month) and collect-results (on the hour).
+    - cron: "30 10 15 * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: local simulation only (no API calls, no cost)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit IonQ Braket circuits
+    runs-on: ubuntu-latest
+    environment: quantum-production
+
+    permissions:
+      contents: write   # to commit pending job files
+      id-token: write   # for OIDC
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1   # IonQ Forte-1 is in us-east-1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Submit jobs
+        env:
+          BRAKET_RESULTS_BUCKET_EAST: ${{ vars.BRAKET_RESULTS_BUCKET_EAST }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          PLATFORM: ionq_braket
+        run: uv run python scripts/submit_benchmark.py
+
+      - name: Commit pending job files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pending/
+          git diff --staged --quiet || git commit -m "chore: submit IonQ Braket benchmark $(date -u +%Y-%m-%d)"
+          git push

--- a/.github/workflows/submit-benchmark-ionq.yml
+++ b/.github/workflows/submit-benchmark-ionq.yml
@@ -1,0 +1,60 @@
+name: Submit IonQ Benchmark
+
+on:
+  schedule:
+    # First of every month at 10:30 UTC.
+    # Offset from collect-results.yml (which runs on the hour) to avoid simultaneous pushes.
+    - cron: "30 10 1 * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: local simulation only (no API calls, no cost)"
+        required: false
+        type: boolean
+        default: false
+      simulator:
+        description: "IonQ simulator: cloud simulator (no QPU cost, requires API key)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit IonQ circuits
+    runs-on: ubuntu-latest
+    environment: quantum-production
+
+    permissions:
+      contents: write   # to commit pending job files
+      id-token: write   # for OIDC (not used here but required by environment)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Submit jobs
+        env:
+          IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          USE_SIMULATOR: ${{ inputs.simulator || 'false' }}
+          PLATFORM: ionq_direct
+        run: uv run python scripts/submit_benchmark.py
+
+      - name: Commit pending job files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pending/
+          git diff --staged --quiet || git commit -m "chore: submit IonQ benchmark $(date -u +%Y-%m-%d)"
+          git push

--- a/.github/workflows/submit-benchmark-iqm.yml
+++ b/.github/workflows/submit-benchmark-iqm.yml
@@ -1,0 +1,59 @@
+name: Submit IQM Benchmark
+
+on:
+  schedule:
+    # Every Wednesday at 10:30 UTC — offset from Rigetti/AQT (Tuesday) and collect (on the hour).
+    - cron: "30 10 * * 3"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: local simulation only (no API calls, no cost)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit IQM circuits
+    runs-on: ubuntu-latest
+    environment: quantum-production
+
+    permissions:
+      contents: write   # to commit pending job files
+      id-token: write   # for OIDC
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-north-1   # IQM Garnet is in eu-north-1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Submit jobs
+        env:
+          BRAKET_RESULTS_BUCKET_EU: ${{ vars.BRAKET_RESULTS_BUCKET_EU }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          PLATFORM: iqm_braket
+        run: uv run python scripts/submit_benchmark.py
+
+      - name: Commit pending job files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pending/
+          git diff --staged --quiet || git commit -m "chore: submit IQM benchmark $(date -u +%Y-%m-%d)"
+          git push

--- a/.github/workflows/submit-benchmark.yml
+++ b/.github/workflows/submit-benchmark.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Submit jobs
         env:
-          BRAKET_RESULTS_BUCKET: ${{ vars.BRAKET_RESULTS_BUCKET }}
+          BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           USE_SIMULATOR: ${{ inputs.simulator || 'false' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,9 @@ Per run: sample **10 circuits** stratified across lengths/states, **100 shots** 
 |---|---|---|---|
 | Rigetti Ankaa-3 | `rigetti_braket` | AWS Braket (OIDC/IAM) | Active — automated weekly (Tuesdays 10:00 UTC) |
 | AQT | `aqt_qiskit` | Qiskit + qiskit-aqt-provider (`AQT_API_KEY`) | Active — automated weekly (Tuesdays 10:00 UTC); hardware window Tue/Wed 10:00–17:00 CET |
+
 | IonQ Aria-1 | `ionq_braket` | AWS Braket (OIDC/IAM) | Paused (budget) |
+| IonQ Forte-1 | `ionq_direct` | IonQ REST API (`IONQ_API_KEY`) | Active — automated monthly (1st of month 10:30 UTC) via submit-benchmark-ionq.yml |
 | IBM Brisbane | `ibm_qiskit` | Qiskit Runtime (`IBM_QUANTUM_TOKEN`) | Active — automated monthly; historical data Feb–Jun 2025 (Sami); org account is `Qiskit Runtime - Standard` (pay-as-you-go) |
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Per run: sample **10 circuits** stratified across lengths/states, **100 shots** 
 | IonQ Aria-1 | `ionq_braket` | AWS Braket (OIDC/IAM) | Paused (budget) |
 | IonQ Forte-1 (direct) | `ionq_direct` | IonQ REST API (`IONQ_API_KEY`) | Active — automated monthly (1st of month 10:30 UTC) via submit-benchmark-ionq.yml |
 | IonQ Forte-1 (Braket) | `ionq_braket` | AWS Braket (OIDC/IAM, us-east-1); `BRAKET_RESULTS_BUCKET_EAST` | Active — automated monthly (15th of month 10:30 UTC) via submit-benchmark-ionq-braket.yml |
+| IQM Garnet | `iqm_braket` | AWS Braket (OIDC/IAM, eu-north-1); `BRAKET_RESULTS_BUCKET_EU` | Active — automated weekly (Wednesdays 10:30 UTC) via submit-benchmark-iqm.yml |
 | IBM Brisbane | `ibm_qiskit` | Qiskit Runtime (`IBM_QUANTUM_TOKEN`) | Active — automated monthly; historical data Feb–Jun 2025 (Sami); org account is `Qiskit Runtime - Standard` (pay-as-you-go) |
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Per run: sample **10 circuits** stratified across lengths/states, **100 shots** 
 
 | Platform | Module | Access path | Status |
 |---|---|---|---|
-| Rigetti Ankaa-3 | `rigetti_braket` | AWS Braket (OIDC/IAM) | Active — automated weekly (Tuesdays 10:00 UTC) |
+| Rigetti Ankaa-3 | `rigetti_braket` | AWS Braket (OIDC/IAM, us-west-1); `BRAKET_RESULTS_BUCKET_WEST` | Active — automated weekly (Tuesdays 10:00 UTC) |
 | AQT | `aqt_qiskit` | Qiskit + qiskit-aqt-provider (`AQT_API_KEY`) | Active — automated weekly (Tuesdays 10:00 UTC); hardware window Tue/Wed 10:00–17:00 CET |
 
 | IonQ Aria-1 | `ionq_braket` | AWS Braket (OIDC/IAM) | Paused (budget) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ Per run: sample **10 circuits** stratified across lengths/states, **100 shots** 
 | AQT | `aqt_qiskit` | Qiskit + qiskit-aqt-provider (`AQT_API_KEY`) | Active — automated weekly (Tuesdays 10:00 UTC); hardware window Tue/Wed 10:00–17:00 CET |
 
 | IonQ Aria-1 | `ionq_braket` | AWS Braket (OIDC/IAM) | Paused (budget) |
-| IonQ Forte-1 | `ionq_direct` | IonQ REST API (`IONQ_API_KEY`) | Active — automated monthly (1st of month 10:30 UTC) via submit-benchmark-ionq.yml |
+| IonQ Forte-1 (direct) | `ionq_direct` | IonQ REST API (`IONQ_API_KEY`) | Active — automated monthly (1st of month 10:30 UTC) via submit-benchmark-ionq.yml |
+| IonQ Forte-1 (Braket) | `ionq_braket` | AWS Braket (OIDC/IAM, us-east-1); `BRAKET_RESULTS_BUCKET_EAST` | Active — automated monthly (15th of month 10:30 UTC) via submit-benchmark-ionq-braket.yml |
 | IBM Brisbane | `ibm_qiskit` | Qiskit Runtime (`IBM_QUANTUM_TOKEN`) | Active — automated monthly; historical data Feb–Jun 2025 (Sami); org account is `Qiskit Runtime - Standard` (pay-as-you-go) |
 
 ## Project Structure

--- a/benchmarks/ionq_braket.py
+++ b/benchmarks/ionq_braket.py
@@ -1,9 +1,13 @@
 """
-IonQ benchmark via AWS Braket.
+IonQ Forte-1 benchmark via AWS Braket.
 
 Authentication: OIDC-assumed IAM role (set up in infra/). No explicit credentials needed.
 SDK: amazon-braket-sdk
-Backend: IonQ Aria-1
+Backend: IonQ Forte-1 (us-east-1)
+Results bucket: BRAKET_RESULTS_BUCKET_EAST (us-east-1) — distinct from the Rigetti/us-west-1 bucket.
+
+Uses explicit us-east-1 boto3 sessions throughout so this module works correctly even when
+the GitHub Actions workflow configures credentials with a different default region.
 
 IonQ queues can be measured in days. This module uses a two-stage approach:
   - submit()  → submit jobs, return a pending dict to be saved to disk
@@ -17,20 +21,25 @@ from datetime import UTC, date, datetime
 
 from benchmarks.circuits import REFERENCE_TABLE, build_circuit_braket, sample_circuits
 
-PLATFORM = "ionq"
-BACKEND_ARN = "arn:aws:braket:us-east-1::device/qpu/ionq/Aria-1"
-SV1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
-
+PLATFORM = "ionq_braket"
+BACKEND_ARN = "arn:aws:braket:us-east-1::device/qpu/ionq/Forte-1"
+AWS_REGION = "us-east-1"
 S3_PREFIX = "condenser-results"
 
 _TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
 
 
 def _s3_folder() -> tuple[str, str]:
-    bucket = os.environ.get("BRAKET_RESULTS_BUCKET")
+    bucket = os.environ.get("BRAKET_RESULTS_BUCKET_EAST")
     if not bucket:
-        raise RuntimeError("BRAKET_RESULTS_BUCKET environment variable is not set")
+        raise RuntimeError("BRAKET_RESULTS_BUCKET_EAST environment variable is not set")
     return (bucket, S3_PREFIX)
+
+
+def _aws_session():
+    import boto3
+    from braket.aws import AwsSession
+    return AwsSession(boto3.Session(region_name=AWS_REGION))
 
 
 def submit(
@@ -38,8 +47,14 @@ def submit(
 ) -> dict:
     """
     Submit circuits and return a pending dict.
-    The caller is responsible for saving this to pending/ionq/<date>.json.
+    The caller is responsible for saving this to pending/ionq_braket/<date>.json.
     """
+    if use_simulator:
+        raise RuntimeError(
+            "Cloud simulator not supported for ionq_braket (SV1 blocked by org SCP). "
+            "Use --dry-run for local simulation."
+        )
+
     from braket.aws import AwsDevice
     from braket.devices import LocalSimulator
 
@@ -49,14 +64,8 @@ def submit(
         device = LocalSimulator()
         backend = "LocalSimulator"
         s3_folder = ("dry-run-bucket", S3_PREFIX)
-    elif use_simulator:
-        import boto3
-        from braket.aws import AwsSession
-        device = AwsDevice(SV1_ARN, aws_session=AwsSession(boto3.Session(region_name="us-east-1")))
-        backend = "SV1"
-        s3_folder = _s3_folder()
     else:
-        device = AwsDevice(BACKEND_ARN)
+        device = AwsDevice(BACKEND_ARN, aws_session=_aws_session())
         backend = device.name
         s3_folder = _s3_folder()
 
@@ -77,7 +86,6 @@ def submit(
         "shots": shots,
         "submitted_at": datetime.now(UTC).isoformat(),
         "dry_run": dry_run,
-        "use_simulator": use_simulator,
         "jobs": [
             {"job_id": task.id, "input_bits": input_bits, "circuit_length": circuit_length}
             for task, (input_bits, circuit_length) in zip(tasks, sampled_keys)
@@ -112,17 +120,9 @@ def _collect_tasks(jobs_meta: list, tasks: list, pending: dict) -> list[dict]:
             "job_start_time": getattr(metadata, "createdAt", None),
             "job_end_time": getattr(metadata, "endedAt", None),
             "sdk_version": pending["sdk_version"],
-            "notes": _notes(pending),
+            "notes": "dry_run",
         })
     return results
-
-
-def _notes(pending: dict) -> str:
-    if pending.get("dry_run"):
-        return "dry_run"
-    if pending.get("use_simulator"):
-        return "simulator"
-    return ""
 
 
 def collect(pending: dict) -> list[dict] | None:
@@ -138,8 +138,9 @@ def collect(pending: dict) -> list[dict] | None:
 
     from braket.aws import AwsQuantumTask
 
+    aws_session = _aws_session()
     jobs = pending["jobs"]
-    tasks = [AwsQuantumTask(job["job_id"]) for job in jobs]
+    tasks = [AwsQuantumTask(job["job_id"], aws_session=aws_session) for job in jobs]
     states = [task.state() for task in tasks]
 
     failed = [job["job_id"] for job, state in zip(jobs, states) if state in ("FAILED", "CANCELLED")]
@@ -175,6 +176,6 @@ def collect(pending: dict) -> list[dict] | None:
             "job_start_time": getattr(metadata, "createdAt", None),
             "job_end_time": getattr(metadata, "endedAt", None),
             "sdk_version": pending["sdk_version"],
-            "notes": _notes(pending),
+            "notes": "",
         })
     return results

--- a/benchmarks/ionq_direct.py
+++ b/benchmarks/ionq_direct.py
@@ -1,0 +1,230 @@
+"""
+IonQ Forte-1 benchmark via the IonQ REST API.
+
+Authentication: IONQ_API_KEY environment variable (GitHub secret in quantum-production).
+Backend: IonQ Forte-1 (qpu.forte-1)
+Project: quantum-stability (2237ddcc-2644-4dc1-b971-b3cbece475e1)
+
+Each circuit is submitted as an individual job so each job_id maps directly to one
+(input_bits, circuit_length) — no batch/child complexity.
+
+IonQ result keys use LSB convention: qubit 0 is bit 0 of the integer key.
+So key "2" = binary "10" reversed = our bitstring "01".
+
+Forte-1 typically completes in ~13 seconds, so collect() will usually return
+results on the first check after the 6-hour collect cycle.
+"""
+
+import json
+import os
+import time
+from datetime import UTC, date, datetime
+
+import requests
+
+from benchmarks.circuits import REFERENCE_TABLE, sample_circuits
+
+PLATFORM = "ionq"
+BACKEND = "Forte-1"
+TARGET = "qpu.forte-1"
+SIMULATOR_TARGET = "simulator"
+PROJECT_ID = "2237ddcc-2644-4dc1-b971-b3cbece475e1"
+IONQ_BASE = "https://api.ionq.co/v0.3"
+
+_TERMINAL_STATES = {"completed", "failed", "cancelled"}
+
+
+def _api_key() -> str:
+    key = os.environ.get("IONQ_API_KEY")
+    if not key:
+        raise RuntimeError("IONQ_API_KEY environment variable is not set")
+    return key
+
+
+def _headers() -> dict:
+    return {"Authorization": f"apiKey {_api_key()}"}
+
+
+def _build_native_circuit(input_bits: str, circuit_length: int) -> dict:
+    """Build an IonQ native circuit definition for our CNOT litmus circuit."""
+    ops = []
+    if input_bits[0] == "1":
+        ops.append({"gate": "x", "target": 0})
+    if input_bits[1] == "1":
+        ops.append({"gate": "x", "target": 1})
+    for i in range(circuit_length):
+        if i % 2 == 0:
+            ops.append({"gate": "cnot", "control": 0, "target": 1})
+        else:
+            ops.append({"gate": "cnot", "control": 1, "target": 0})
+    return {"qubits": 2, "circuit": ops}
+
+
+def _lsb_key_to_bits(key: str) -> str:
+    """Convert IonQ decimal result key to our 2-qubit bitstring (LSB convention)."""
+    return format(int(key), "02b")[::-1]
+
+
+def _raw_to_counts(raw_results: dict, shots: int) -> dict[str, int]:
+    """Convert IonQ probability dict to shot counts keyed by our bitstring notation."""
+    counts = {}
+    for k, prob in raw_results.items():
+        bitstring = _lsb_key_to_bits(k)
+        count = round(prob * shots)
+        if count > 0:
+            counts[bitstring] = count
+    return counts
+
+
+def submit(
+    n_circuits: int = 10, shots: int = 100, dry_run: bool = False, use_simulator: bool = False
+) -> dict:
+    """
+    Submit circuits to IonQ Forte-1 and return a pending dict.
+    The caller is responsible for saving this to pending/ionq_direct/<date>.json.
+    """
+    sampled_keys = sample_circuits(n_circuits)
+    run_date = date.today().isoformat()
+    submitted_at = datetime.now(UTC).isoformat()
+
+    if dry_run:
+        # Local simulation — no API calls, perfect results from REFERENCE_TABLE
+        jobs = [
+            {"job_id": f"dry-run-{i}", "input_bits": ib, "circuit_length": cl}
+            for i, (ib, cl) in enumerate(sampled_keys)
+        ]
+        dry_results = []
+        for job in jobs:
+            ib, cl = job["input_bits"], job["circuit_length"]
+            correct = REFERENCE_TABLE[(ib, cl)]
+            dry_results.append({
+                "run_date": run_date,
+                "platform": PLATFORM,
+                "backend": "LocalSim",
+                "input_bits": ib,
+                "circuit_length": cl,
+                "shots": shots,
+                "counts_json": json.dumps({correct: shots}),
+                "success_probability": 1.0,
+                "job_id": job["job_id"],
+                "job_start_time": submitted_at,
+                "job_end_time": submitted_at,
+                "sdk_version": "",
+                "notes": "dry_run",
+            })
+        return {
+            "run_date": run_date,
+            "platform": PLATFORM,
+            "backend": "LocalSim",
+            "shots": shots,
+            "submitted_at": submitted_at,
+            "dry_run": True,
+            "jobs": jobs,
+            "_dry_run_results": dry_results,
+        }
+
+    target = SIMULATOR_TARGET if use_simulator else TARGET
+    backend = "simulator" if use_simulator else BACKEND
+    hdrs = {**_headers(), "Content-Type": "application/json"}
+    jobs = []
+
+    for input_bits, circuit_length in sampled_keys:
+        body = {
+            "name": f"cnot_len{circuit_length}_{input_bits}",
+            "target": target,
+            "shots": shots,
+            "project_id": PROJECT_ID,
+            "circuit": _build_native_circuit(input_bits, circuit_length),
+        }
+        resp = requests.post(f"{IONQ_BASE}/jobs", headers=hdrs, json=body, timeout=30)
+        resp.raise_for_status()
+        job_id = resp.json()["id"]
+        jobs.append({"job_id": job_id, "input_bits": input_bits, "circuit_length": circuit_length})
+        print(f"    Submitted cnot_len{circuit_length}_{input_bits}: {job_id}")
+        time.sleep(0.2)  # be gentle with the API
+
+    print(f"  Submitted {len(jobs)} circuits to {target}")
+    return {
+        "run_date": run_date,
+        "platform": PLATFORM,
+        "backend": backend,
+        "shots": shots,
+        "submitted_at": submitted_at,
+        "dry_run": False,
+        "use_simulator": use_simulator,
+        "jobs": jobs,
+    }
+
+
+def collect(pending: dict) -> list[dict] | None:
+    """
+    Check job status and collect results.
+
+    Returns a list of result dicts if all jobs are complete.
+    Returns None if any jobs are still running.
+    Raises RuntimeError if any jobs failed or were cancelled.
+    """
+    if "_dry_run_results" in pending:
+        return pending["_dry_run_results"]
+
+    hdrs = _headers()
+    shots = pending["shots"]
+    results = []
+    still_pending = []
+
+    for job_meta in pending["jobs"]:
+        job_id = job_meta["job_id"]
+        resp = requests.get(f"{IONQ_BASE}/jobs/{job_id}", headers=hdrs, timeout=30)
+        resp.raise_for_status()
+        job = resp.json()
+        status = job.get("status", "")
+
+        if status in ("failed", "cancelled"):
+            raise RuntimeError(f"Job {job_id} {status}")
+        if status != "completed":
+            still_pending.append(job_id)
+            continue
+
+        res_resp = requests.get(f"{IONQ_BASE}/jobs/{job_id}/results", headers=hdrs, timeout=30)
+        res_resp.raise_for_status()
+        raw = res_resp.json()
+
+        input_bits = job_meta["input_bits"]
+        circuit_length = job_meta["circuit_length"]
+        counts = _raw_to_counts(raw, shots)
+        correct = REFERENCE_TABLE[(input_bits, circuit_length)]
+        success_prob = counts.get(correct, 0) / shots
+
+        start_ts = job.get("start")
+        end_ts = job.get("response")
+        results.append({
+            "run_date": pending["run_date"],
+            "platform": pending["platform"],
+            "backend": pending["backend"],
+            "input_bits": input_bits,
+            "circuit_length": circuit_length,
+            "shots": shots,
+            "counts_json": json.dumps(counts),
+            "success_probability": round(success_prob, 4),
+            "job_id": job_id,
+            "job_start_time": datetime.fromtimestamp(start_ts, tz=UTC).isoformat() if start_ts else "",
+            "job_end_time": datetime.fromtimestamp(end_ts, tz=UTC).isoformat() if end_ts else "",
+            "sdk_version": "",
+            "notes": _notes(pending),
+        })
+        time.sleep(0.1)
+
+    if still_pending:
+        print(f"  {len(still_pending)}/{len(pending['jobs'])} jobs still pending.")
+        return None
+
+    print(f"  All {len(results)} jobs complete.")
+    return results
+
+
+def _notes(pending: dict) -> str:
+    if pending.get("dry_run"):
+        return "dry_run"
+    if pending.get("use_simulator"):
+        return "simulator"
+    return ""

--- a/benchmarks/iqm_braket.py
+++ b/benchmarks/iqm_braket.py
@@ -1,0 +1,181 @@
+"""
+IQM Garnet benchmark via AWS Braket.
+
+Authentication: OIDC-assumed IAM role (set up in infra/). No explicit credentials needed.
+SDK: amazon-braket-sdk
+Backend: IQM Garnet (eu-north-1, 20-qubit superconducting gate-based QPU)
+Results bucket: BRAKET_RESULTS_BUCKET_EU (eu-north-1)
+
+Uses explicit eu-north-1 boto3 sessions throughout so this module works correctly even when
+the GitHub Actions workflow configures credentials with a different default region.
+
+IQM queues can be measured in hours. This module uses a two-stage approach:
+  - submit()  → submit jobs, return a pending dict to be saved to disk
+  - collect() → check job status, return results if all done, None if still waiting
+"""
+
+import importlib.metadata
+import json
+import os
+from datetime import UTC, date, datetime
+
+from benchmarks.circuits import REFERENCE_TABLE, build_circuit_braket, sample_circuits
+
+PLATFORM = "iqm_braket"
+BACKEND_ARN = "arn:aws:braket:eu-north-1::device/qpu/iqm/Garnet"
+AWS_REGION = "eu-north-1"
+S3_PREFIX = "condenser-results"
+
+_TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+
+def _s3_folder() -> tuple[str, str]:
+    bucket = os.environ.get("BRAKET_RESULTS_BUCKET_EU")
+    if not bucket:
+        raise RuntimeError("BRAKET_RESULTS_BUCKET_EU environment variable is not set")
+    return (bucket, S3_PREFIX)
+
+
+def _aws_session():
+    import boto3
+    from braket.aws import AwsSession
+    return AwsSession(boto3.Session(region_name=AWS_REGION))
+
+
+def submit(
+    n_circuits: int = 10, shots: int = 100, dry_run: bool = False, use_simulator: bool = False
+) -> dict:
+    """
+    Submit circuits and return a pending dict.
+    The caller is responsible for saving this to pending/iqm_braket/<date>.json.
+    """
+    if use_simulator:
+        raise RuntimeError(
+            "Cloud simulator not supported for iqm_braket. "
+            "Use --dry-run for local simulation."
+        )
+
+    from braket.aws import AwsDevice
+    from braket.devices import LocalSimulator
+
+    sdk_version = importlib.metadata.version("amazon-braket-sdk")
+
+    if dry_run:
+        device = LocalSimulator()
+        backend = "LocalSimulator"
+        s3_folder = ("dry-run-bucket", S3_PREFIX)
+    else:
+        device = AwsDevice(BACKEND_ARN, aws_session=_aws_session())
+        backend = device.name
+        s3_folder = _s3_folder()
+
+    sampled_keys = sample_circuits(n_circuits)
+    circuits = [build_circuit_braket(input_bits, length) for input_bits, length in sampled_keys]
+
+    print(f"  Submitting {len(circuits)} circuits to {backend}...")
+    if dry_run:
+        tasks = [device.run(circuit, shots=shots) for circuit in circuits]
+    else:
+        tasks = [device.run(circuit, s3_folder, shots=shots) for circuit in circuits]
+
+    pending = {
+        "run_date": date.today().isoformat(),
+        "platform": PLATFORM,
+        "backend": backend,
+        "sdk_version": sdk_version,
+        "shots": shots,
+        "submitted_at": datetime.now(UTC).isoformat(),
+        "dry_run": dry_run,
+        "jobs": [
+            {"job_id": task.id, "input_bits": input_bits, "circuit_length": circuit_length}
+            for task, (input_bits, circuit_length) in zip(tasks, sampled_keys)
+        ],
+    }
+
+    if dry_run:
+        pending["_dry_run_results"] = _collect_tasks(pending["jobs"], tasks, pending)
+
+    return pending
+
+
+def _collect_tasks(jobs_meta: list, tasks: list, pending: dict) -> list[dict]:
+    """Build result dicts from already-completed task objects (used for dry runs)."""
+    results = []
+    for job_meta, task in zip(jobs_meta, tasks):
+        result = task.result()
+        counts = dict(result.measurement_counts)
+        correct = REFERENCE_TABLE[(job_meta["input_bits"], job_meta["circuit_length"])]
+        success_prob = counts.get(correct, 0) / pending["shots"]
+        metadata = result.task_metadata
+        results.append({
+            "run_date": pending["run_date"],
+            "platform": pending["platform"],
+            "backend": pending["backend"],
+            "input_bits": job_meta["input_bits"],
+            "circuit_length": job_meta["circuit_length"],
+            "shots": pending["shots"],
+            "counts_json": json.dumps(counts),
+            "success_probability": round(success_prob, 4),
+            "job_id": job_meta["job_id"],
+            "job_start_time": getattr(metadata, "createdAt", None),
+            "job_end_time": getattr(metadata, "endedAt", None),
+            "sdk_version": pending["sdk_version"],
+            "notes": "dry_run",
+        })
+    return results
+
+
+def collect(pending: dict) -> list[dict] | None:
+    """
+    Check the status of pending jobs.
+
+    Returns a list of result dicts (matching the CSV schema) if all jobs are done.
+    Returns None if any jobs are still queued or running.
+    Raises RuntimeError if any jobs failed or were cancelled.
+    """
+    if "_dry_run_results" in pending:
+        return pending["_dry_run_results"]
+
+    from braket.aws import AwsQuantumTask
+
+    aws_session = _aws_session()
+    jobs = pending["jobs"]
+    tasks = [AwsQuantumTask(job["job_id"], aws_session=aws_session) for job in jobs]
+    states = [task.state() for task in tasks]
+
+    failed = [job["job_id"] for job, state in zip(jobs, states) if state in ("FAILED", "CANCELLED")]
+    if failed:
+        raise RuntimeError(f"Jobs failed/cancelled: {failed}")
+
+    still_pending = [
+        job["job_id"] for job, state in zip(jobs, states) if state not in _TERMINAL_STATES
+    ]
+    if still_pending:
+        print(f"  {len(still_pending)}/{len(jobs)} jobs still pending.")
+        return None
+
+    print(f"  All {len(jobs)} jobs complete. Collecting results...")
+    results = []
+    for job_meta, task in zip(jobs, tasks):
+        result = task.result()
+        counts = dict(result.measurement_counts)
+        correct = REFERENCE_TABLE[(job_meta["input_bits"], job_meta["circuit_length"])]
+        success_prob = counts.get(correct, 0) / pending["shots"]
+
+        metadata = result.task_metadata
+        results.append({
+            "run_date": pending["run_date"],
+            "platform": pending["platform"],
+            "backend": pending["backend"],
+            "input_bits": job_meta["input_bits"],
+            "circuit_length": job_meta["circuit_length"],
+            "shots": pending["shots"],
+            "counts_json": json.dumps(counts),
+            "success_probability": round(success_prob, 4),
+            "job_id": job_meta["job_id"],
+            "job_start_time": getattr(metadata, "createdAt", None),
+            "job_end_time": getattr(metadata, "endedAt", None),
+            "sdk_version": pending["sdk_version"],
+            "notes": "",
+        })
+    return results

--- a/benchmarks/rigetti_braket.py
+++ b/benchmarks/rigetti_braket.py
@@ -26,9 +26,9 @@ _TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
 
 
 def _s3_folder() -> tuple[str, str]:
-    bucket = os.environ.get("BRAKET_RESULTS_BUCKET")
+    bucket = os.environ.get("BRAKET_RESULTS_BUCKET_WEST")
     if not bucket:
-        raise RuntimeError("BRAKET_RESULTS_BUCKET environment variable is not set")
+        raise RuntimeError("BRAKET_RESULTS_BUCKET_WEST environment variable is not set")
     return (bucket, S3_PREFIX)
 
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -29,7 +29,7 @@ aws s3api create-bucket \
 Do **not** rename or touch any existing Braket result prefixes — historical notebooks may still
 write there. The new bucket is only for automated condenser runs going forward.
 
-Edit `iam-policy.json` to replace `YOUR_BRAKET_RESULTS_BUCKET` with your chosen bucket name
+Edit `iam-policy.json` to replace `YOUR_BRAKET_RESULTS_BUCKET_WEST` with your chosen bucket name
 before running Step 3.
 
 ---
@@ -74,7 +74,7 @@ aws iam create-role \
 
 ### 3. Attach the permissions policy
 
-Edit `iam-policy.json` — replace `YOUR_BRAKET_RESULTS_BUCKET` with the S3 bucket name.
+Edit `iam-policy.json` — replace `YOUR_BRAKET_RESULTS_BUCKET_WEST` with the S3 bucket name.
 
 ```bash
 aws iam put-role-policy \
@@ -97,7 +97,7 @@ Go to: GitHub repo → Settings → Environments → `quantum-production` → Ad
 
 This is *not* a secret — bucket names aren't sensitive. Go to:
 GitHub repo → Settings → Variables → Actions → New repository variable
-- Name: `BRAKET_RESULTS_BUCKET`
+- Name: `BRAKET_RESULTS_BUCKET_WEST`
 - Value: your S3 bucket name
 
 This is the single source of truth for the bucket name in the workflow. The IAM policy

--- a/infra/iam-policy.json
+++ b/infra/iam-policy.json
@@ -25,8 +25,8 @@
       "Resource": [
         "arn:aws:s3:::amazon-braket-isc-condenser-west",
         "arn:aws:s3:::amazon-braket-isc-condenser-west/*",
-        "arn:aws:s3:::amazon-braket-isc-condenser",
-        "arn:aws:s3:::amazon-braket-isc-condenser/*"
+        "arn:aws:s3:::amazon-braket-isc-condenser-east",
+        "arn:aws:s3:::amazon-braket-isc-condenser-east/*"
       ]
     }
   ]

--- a/infra/iam-policy.json
+++ b/infra/iam-policy.json
@@ -23,8 +23,10 @@
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::YOUR_BRAKET_RESULTS_BUCKET",
-        "arn:aws:s3:::YOUR_BRAKET_RESULTS_BUCKET/*"
+        "arn:aws:s3:::amazon-braket-isc-condenser-west",
+        "arn:aws:s3:::amazon-braket-isc-condenser-west/*",
+        "arn:aws:s3:::amazon-braket-isc-condenser",
+        "arn:aws:s3:::amazon-braket-isc-condenser/*"
       ]
     }
   ]

--- a/infra/iam-policy.json
+++ b/infra/iam-policy.json
@@ -26,7 +26,9 @@
         "arn:aws:s3:::amazon-braket-isc-condenser-west",
         "arn:aws:s3:::amazon-braket-isc-condenser-west/*",
         "arn:aws:s3:::amazon-braket-isc-condenser-east",
-        "arn:aws:s3:::amazon-braket-isc-condenser-east/*"
+        "arn:aws:s3:::amazon-braket-isc-condenser-east/*",
+        "arn:aws:s3:::amazon-braket-isc-condenser-eu",
+        "arn:aws:s3:::amazon-braket-isc-condenser-eu/*"
       ]
     }
   ]

--- a/infra/iam-trust-policy.json
+++ b/infra/iam-trust-policy.json
@@ -10,7 +10,7 @@
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": "repo:InsightSoftmax/condenser:environment:quantum-production"
+          "token.actions.githubusercontent.com:sub": "repo:InsightSoftmax/quantum-stability:environment:quantum-production"
         }
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "qiskit>=1.0.0",
     "qiskit-aqt-provider>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",
+    "requests>=2.32.0",
     "pandas>=2.2.0",
     "matplotlib>=3.9.0",
     "seaborn>=0.13.0",

--- a/scripts/cost_estimate.py
+++ b/scripts/cost_estimate.py
@@ -61,16 +61,16 @@ BRAKET_PRICING: dict[str, dict] = {
                           " Forte-1 is the current Braket-listed IonQ device.",
     },
     "IonQ Forte-1 (direct REST API)": {
-        "per_task_usd":   0.00,    # no per-task fee; IonQ charges per gate + per shot
-        "per_shot_usd":   0.00975,
+        "per_task_usd":   25.88,   # observed: $7,762 / 300 circuits from Claire's account (2025)
+        "per_shot_usd":   0.00,    # gate + shot charges rolled into per_task_usd observation
         "region":         "IonQ cloud (direct)",
         "access":         "ionq_direct (REST API, IONQ_API_KEY)",
         "status":         "active",
         "module":         "ionq_direct",
         "runs_per_year":  12,   # monthly (1st of month)
-        "notes":          "IonQ also charges per native gate (~$0.00022/gate × qubit count)."
-                          " Gate cost for our 2-qubit circuits is small relative to shot cost."
-                          " Verify at https://ionq.com/pricing.",
+        "notes":          "Cost derived from observed billing: $7,762 for 300 circuits."
+                          " IonQ charges per gate + per shot; exact rate not published."
+                          " Verify current pricing at https://ionq.com/pricing.",
     },
     "AQT IBEX-Q1 (direct, qiskit-aqt-provider)": {
         "per_task_usd":   0.30 * EUR_TO_USD,   # 0.30 EUR/circuit

--- a/scripts/cost_estimate.py
+++ b/scripts/cost_estimate.py
@@ -38,16 +38,39 @@ BRAKET_PRICING: dict[str, dict] = {
         "access":         "AWS Braket",
         "status":         "active",
         "module":         "rigetti_braket",
+        "runs_per_year":  52,   # weekly
     },
-    "IonQ Forte": {
+    "IQM Garnet": {
+        "per_task_usd":   0.30,
+        "per_shot_usd":   0.00145,
+        "region":         "eu-north-1",
+        "access":         "AWS Braket",
+        "status":         "active",
+        "module":         "iqm_braket",
+        "runs_per_year":  52,   # weekly
+    },
+    "IonQ Forte-1 (via Braket)": {
         "per_task_usd":   0.30,
         "per_shot_usd":   0.08000,
         "region":         "us-east-1",
         "access":         "AWS Braket",
-        "status":         "paused (budget)",
+        "status":         "active",
         "module":         "ionq_braket",
+        "runs_per_year":  12,   # monthly (15th of month)
         "notes":          "Historical data used IonQ Aria-1 (~$0.03/shot) and Harmony."
-                          " Forte is the current Braket-listed IonQ device.",
+                          " Forte-1 is the current Braket-listed IonQ device.",
+    },
+    "IonQ Forte-1 (direct REST API)": {
+        "per_task_usd":   0.00,    # no per-task fee; IonQ charges per gate + per shot
+        "per_shot_usd":   0.00975,
+        "region":         "IonQ cloud (direct)",
+        "access":         "ionq_direct (REST API, IONQ_API_KEY)",
+        "status":         "active",
+        "module":         "ionq_direct",
+        "runs_per_year":  12,   # monthly (1st of month)
+        "notes":          "IonQ also charges per native gate (~$0.00022/gate × qubit count)."
+                          " Gate cost for our 2-qubit circuits is small relative to shot cost."
+                          " Verify at https://ionq.com/pricing.",
     },
     "AQT IBEX-Q1 (direct, qiskit-aqt-provider)": {
         "per_task_usd":   0.30 * EUR_TO_USD,   # 0.30 EUR/circuit
@@ -56,6 +79,7 @@ BRAKET_PRICING: dict[str, dict] = {
         "access":         "qiskit-aqt-provider",
         "status":         "active",
         "module":         "aqt_qiskit",
+        "runs_per_year":  52,   # weekly
         "notes":          "Source: quotation Q2511001 (2025-11-04). EUR/USD ≈ 1.09."
                           " Hardware backend name must be confirmed with Arash"
                           " (run provider.backends() to see options).",
@@ -78,6 +102,7 @@ BRAKET_PRICING: dict[str, dict] = {
         "region":         "eu-north-1",
         "access":         "AWS Braket",
         "status":         "alternative",
+        "runs_per_year":  52,
         "notes":          "Braket access available as an alternative to direct."
                           " Pricing is within ~5% of direct (direct is slightly cheaper).",
     },
@@ -125,7 +150,9 @@ def main(argv: list[str] | None = None) -> None:
         task_cost, shot_cost, total = cost_per_run(
             p["per_task_usd"], p["per_shot_usd"], n_circuits, shots
         )
-        annual = total * weeks
+        runs = p.get("runs_per_year", weeks)
+        annual = total * runs
+        freq = "weekly" if runs == 52 else f"monthly ({runs}/yr)" if runs == 12 else f"{runs}/yr"
 
         print(f"  {name}  [{p['status']}]")
         print(f"    Access      : {p['access']}  ({p['region']})")
@@ -133,7 +160,7 @@ def main(argv: list[str] | None = None) -> None:
               f"per shot: {format_usd(p['per_shot_usd'])}")
         print(f"    Per run     : {format_usd(total)}  "
               f"({format_usd(task_cost)} tasks + {format_usd(shot_cost)} shots)")
-        print(f"    Annual      : {format_usd(annual)}  ({weeks} runs)")
+        print(f"    Annual      : {format_usd(annual)}  ({freq})")
         if p.get("notes"):
             print(f"    Note        : {p['notes']}")
         print()
@@ -143,7 +170,8 @@ def main(argv: list[str] | None = None) -> None:
               if v["status"] == "active"}
     if active:
         total_annual = sum(
-            cost_per_run(p["per_task_usd"], p["per_shot_usd"], n_circuits, shots)[2] * weeks
+            cost_per_run(p["per_task_usd"], p["per_shot_usd"], n_circuits, shots)[2]
+            * p.get("runs_per_year", weeks)
             for p in active.values()
         )
         print("-" * 65)

--- a/scripts/submit_benchmark.py
+++ b/scripts/submit_benchmark.py
@@ -27,6 +27,7 @@ ENABLED_PLATFORMS = [
     "ibm_qiskit",      # active: IBM Brisbane via Qiskit Runtime; requires IBM_QUANTUM_TOKEN secret
     # "ionq_direct",   # active: IonQ Forte-1 via REST API — runs monthly via submit-benchmark-ionq.yml
     # "ionq_braket",   # active: IonQ Forte-1 via AWS Braket — runs monthly via submit-benchmark-ionq-braket.yml
+    # "iqm_braket",    # active: IQM Garnet via AWS Braket — runs weekly via submit-benchmark-iqm.yml
 ]
 
 

--- a/scripts/submit_benchmark.py
+++ b/scripts/submit_benchmark.py
@@ -25,7 +25,8 @@ ENABLED_PLATFORMS = [
     "rigetti_braket",  # active: Rigetti Ankaa-3 via AWS Braket (us-west-1)
     "aqt_qiskit",      # active: AQT via qiskit-aqt-provider; requires AQT_API_KEY secret
     "ibm_qiskit",      # active: IBM Brisbane via Qiskit Runtime; requires IBM_QUANTUM_TOKEN secret
-    # "ionq_braket",   # paused: budget
+    # "ionq_direct",   # active: IonQ Forte-1 via REST API — runs monthly via submit-benchmark-ionq.yml
+    # "ionq_braket",   # retired: was Aria-1 via Braket; replaced by ionq_direct
 ]
 
 

--- a/scripts/submit_benchmark.py
+++ b/scripts/submit_benchmark.py
@@ -26,7 +26,7 @@ ENABLED_PLATFORMS = [
     "aqt_qiskit",      # active: AQT via qiskit-aqt-provider; requires AQT_API_KEY secret
     "ibm_qiskit",      # active: IBM Brisbane via Qiskit Runtime; requires IBM_QUANTUM_TOKEN secret
     # "ionq_direct",   # active: IonQ Forte-1 via REST API — runs monthly via submit-benchmark-ionq.yml
-    # "ionq_braket",   # retired: was Aria-1 via Braket; replaced by ionq_direct
+    # "ionq_braket",   # active: IonQ Forte-1 via AWS Braket — runs monthly via submit-benchmark-ionq-braket.yml
 ]
 
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -85,6 +85,29 @@ class TestIonQSimulator:
         _validate_results(results, N_CIRCUITS, SHOTS)
 
 
+class TestIQMSimulator:
+    def test_submit_returns_pending_dict(self):
+        from benchmarks import iqm_braket
+        pending = iqm_braket.submit(n_circuits=N_CIRCUITS, shots=SHOTS, dry_run=True)
+        assert pending["platform"] == "iqm_braket"
+        assert pending["backend"] == "LocalSimulator"
+        assert pending["dry_run"] is True
+        assert len(pending["jobs"]) == N_CIRCUITS
+
+    def test_collect_returns_results(self):
+        from benchmarks import iqm_braket
+        pending = iqm_braket.submit(n_circuits=N_CIRCUITS, shots=SHOTS, dry_run=True)
+        results = iqm_braket.collect(pending)
+        _validate_results(results, N_CIRCUITS, SHOTS)
+
+    def test_full_pipeline_via_json_round_trip(self):
+        from benchmarks import iqm_braket
+        pending = iqm_braket.submit(n_circuits=N_CIRCUITS, shots=SHOTS, dry_run=True)
+        pending_reloaded = json.loads(json.dumps(pending, default=str))
+        results = iqm_braket.collect(pending_reloaded)
+        _validate_results(results, N_CIRCUITS, SHOTS)
+
+
 class TestIBMSimulator:
     def test_submit_returns_pending_dict(self):
         from benchmarks import ibm_qiskit
@@ -101,7 +124,6 @@ class TestIBMSimulator:
         _validate_results(results, N_CIRCUITS, SHOTS)
 
     def test_full_pipeline_via_json_round_trip(self):
-        """Pending dict must survive JSON serialization (as it does when saved to disk)."""
         from benchmarks import ibm_qiskit
         pending = ibm_qiskit.submit(n_circuits=N_CIRCUITS, shots=SHOTS, dry_run=True)
         pending_reloaded = json.loads(json.dumps(pending, default=str))

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -66,7 +66,7 @@ class TestIonQSimulator:
     def test_submit_returns_pending_dict(self):
         from benchmarks import ionq_braket
         pending = ionq_braket.submit(n_circuits=N_CIRCUITS, shots=SHOTS, dry_run=True)
-        assert pending["platform"] == "ionq"
+        assert pending["platform"] == "ionq_braket"
         assert pending["backend"] == "LocalSimulator"
         assert pending["dry_run"] is True
         assert len(pending["jobs"]) == N_CIRCUITS

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,7 @@ dependencies = [
     { name = "qiskit" },
     { name = "qiskit-aqt-provider" },
     { name = "qiskit-ibm-runtime" },
+    { name = "requests" },
     { name = "seaborn" },
 ]
 
@@ -559,6 +560,7 @@ requires-dist = [
     { name = "qiskit", specifier = ">=1.0.0" },
     { name = "qiskit-aqt-provider", specifier = ">=1.0.0" },
     { name = "qiskit-ibm-runtime", specifier = ">=0.20.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "seaborn", specifier = ">=0.13.0" },
 ]
 


### PR DESCRIPTION
## What

Adds `ionq_direct` platform module to run IonQ Forte-1 benchmarks monthly via the IonQ REST API (v0.3), with a dedicated GitHub Actions workflow.

## Changes

- **`benchmarks/ionq_direct.py`** — new platform module: IonQ native circuit format, individual job submissions, LSB bit-order correction, dry-run and simulator modes
- **`.github/workflows/submit-benchmark-ionq.yml`** — runs 1st of each month (10:30 UTC); `PLATFORM=ionq_direct`; `IONQ_API_KEY` from `quantum-production` secret
- **`collect-results.yml`** — passes `IONQ_API_KEY` to the collect step
- **`pyproject.toml`** — adds `requests>=2.32.0`
- **`CLAUDE.md`, `submit_benchmark.py`** — updated platform table and comments

## IonQ project

`quantum-stability` (ID: `2237ddcc-2644-4dc1-b971-b3cbece475e1`)  
Team: Tommy, Claire, Sami, Mo, Arash, Ascammon

## Setup required

Add `IONQ_API_KEY` to the `quantum-production` GitHub Environment secret before the first scheduled run.

## Testing

Dry-run (`--dry-run`) and full submit+collect round-trip verified locally. All 51 tests pass.