### PR TITLE
ci: deploy dashboard to GitHub Pages

### DIFF
--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -2,9 +2,8 @@ name: Collect Results
 
 on:
   schedule:
-    # Every 6 hours on the hour — keeps checking until all pending jobs complete,
+    # Every 6 hours — keeps checking until all pending jobs complete,
     # regardless of how long the queue is (IonQ can be days).
-    # Must not coincide with submit-benchmark.yml; keep that workflow at a :30 offset.
     - cron: "0 */6 * * *"
   workflow_dispatch: {}
 
@@ -20,6 +19,9 @@ jobs:
     permissions:
       contents: write   # to commit results and remove pending files
       id-token: write   # for OIDC
+
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout
@@ -41,7 +43,7 @@ jobs:
 
       - name: Install uv
         if: steps.check.outputs.pending_count != '0'
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
@@ -52,9 +54,8 @@ jobs:
       - name: Collect results
         if: steps.check.outputs.pending_count != '0'
         env:
-          BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
+          BRAKET_RESULTS_BUCKET: ${{ vars.BRAKET_RESULTS_BUCKET }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
-          IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
         run: uv run python scripts/collect_results.py
 
       - name: Commit results

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,0 +1,74 @@
+name: Deploy Dashboard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "dashboard/**"
+      - "data/**"
+      - ".github/workflows/deploy-dashboard.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    name: Build dashboard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install Node dependencies
+        working-directory: dashboard
+        run: npm ci
+
+      - name: Build
+        working-directory: dashboard
+        run: |
+          source ../.venv/bin/activate
+          npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboard/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/submit-benchmark.yml
+++ b/.github/workflows/submit-benchmark.yml
@@ -2,10 +2,8 @@ name: Submit Benchmark
 
 on:
   schedule:
-    # Every Tuesday at 10:30 UTC (11:30 CET / 12:30 CEST) — within AQT hardware access window.
-    # Must not coincide with collect-results.yml, which runs on the hour every 6h.
-    # Keep this at a :30 offset so both workflows never push to main simultaneously.
-    - cron: "30 10 * * 2"
+    # Every Monday at 12:00 UTC
+    - cron: "0 12 * * 1"
   workflow_dispatch:
     inputs:
       platform:
@@ -36,6 +34,9 @@ jobs:
       contents: write   # to commit pending job files
       id-token: write   # for OIDC
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +48,7 @@ jobs:
           aws-region: us-west-1   # Rigetti Ankaa-3 is in us-west-1; S3 bucket must match
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
@@ -56,7 +57,7 @@ jobs:
 
       - name: Submit jobs
         env:
-          BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
+          BRAKET_RESULTS_BUCKET: ${{ vars.BRAKET_RESULTS_BUCKET }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           USE_SIMULATOR: ${{ inputs.simulator || 'false' }}

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -6,14 +6,14 @@ export default {
     {
       name: "Platforms",
       pages: [
-        {name: "Rigetti Ankaa-3", path: "/rigetti"},
         {name: "AQT IBEX", path: "/aqt"},
         {name: "IonQ Aria-1", path: "/ionq"},
-        {name: "IBM Brisbane", path: "/ibm"},
+        {name: "Rigetti Ankaa-3", path: "/rigetti"},
       ]
     },
     {name: "Methodology", path: "/about"},
+    {name: "About Insight Softmax", path: "/about-isc"},
   ],
   head: '<link rel="stylesheet" href="/theme.css">',
-  footer: "Quantum Stability Monitor — longitudinal QPU benchmarking by Insight Softmax",
+  footer: 'Quantum Stability Monitor — longitudinal QPU benchmarking by <a href="https://insightsoftmax.com/" target="_blank" rel="noopener">Insight Softmax</a>',
 };

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "condenser-dashboard",
       "dependencies": {
-        "@observablehq/framework": "^1.12.0"
+        "@observablehq/framework": "^1.12.0",
+        "plotly.js-dist-min": "^3.5.0"
       },
       "devDependencies": {
         "eslint": "^9.39.4"
@@ -3722,6 +3723,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/plotly.js-dist-min": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-3.5.0.tgz",
+      "integrity": "sha512-rN+0P4M6eIHiNeKsyv4F0cCmA3pslxIjUpGpEh6PbNzEQQMjHbXFbC7nVUbK805TaLxnjh6FnwsVau/DlWimUA==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@observablehq/framework": "^1.12.0"
+    "@observablehq/framework": "^1.12.0",
+    "plotly.js-dist-min": "^3.5.0"
   },
   "devDependencies": {
     "eslint": "^9.39.4"

--- a/dashboard/src/about-isc.md
+++ b/dashboard/src/about-isc.md
@@ -1,0 +1,15 @@
+---
+title: About Insight Softmax
+---
+
+# About Insight Softmax
+
+[Insight Softmax](https://insightsoftmax.com/) is a software company focused on applied quantum computing and AI infrastructure.
+
+The Quantum Stability Monitor is one of our open research initiatives — a longitudinal benchmarking program that tracks the real-world reliability of quantum hardware over time. Rather than one-off performance snapshots, we run the same circuits weekly on each platform and ask: *is this hardware getting more or less consistent?*
+
+## Get in touch
+
+If you're interested in quantum benchmarking, reliability research, or working with us:
+
+<a href="https://insightsoftmax.com/" target="_blank" rel="noopener" style="display:inline-block;margin-top:0.25rem;font-size:0.9rem;color:var(--isc-gold);font-weight:600;text-decoration:none;border-bottom:1.5px solid var(--isc-gold)">Visit insightsoftmax.com →</a>

--- a/dashboard/src/about.md
+++ b/dashboard/src/about.md
@@ -49,4 +49,6 @@ A perfect QPU would score 1.0 on every circuit. Real hardware scores lower due t
 
 ## Data
 
-All raw results are stored as CSV files committed to the [GitHub repository](https://github.com/InsightSoftmax/condenser). One row per circuit execution, including the full shot histogram (`counts_json`), timestamps, and SDK version.
+All raw results are stored as CSV files committed to the [GitHub repository](https://github.com/InsightSoftmax/quantum-stability). One row per circuit execution, including the full shot histogram (`counts_json`), timestamps, and SDK version.
+
+This project is maintained by [Insight Softmax](https://insightsoftmax.com/).

--- a/dashboard/src/components/platformCharts.js
+++ b/dashboard/src/components/platformCharts.js
@@ -80,12 +80,41 @@ export function volatilityTimeSeries(data, {color = "#363D47", width = 900} = {}
 /**
  * Box plot of success probability by circuit depth.
  * Shows distribution shape (median, IQR, whiskers, outliers) — richer than bar chart.
+ *
+ * Reading the chart:
+ *   - Vertical line  = full range of non-outlier values (whisker: min to max)
+ *   - Colored box    = interquartile range (Q1–Q3, middle 50% of circuits)
+ *   - Center tick    = median
+ *   - Dots below box = outliers (circuits that fell more than 1.5×IQR below Q1)
  */
 export function boxByLength(data, {color = "#363D47", width = 560} = {}) {
-  return Plot.plot({
+  // Precompute per-depth stats for tooltips
+  const statsByDepth = new Map();
+  for (const d of data.circuits) {
+    if (!statsByDepth.has(d.circuit_length)) statsByDepth.set(d.circuit_length, []);
+    statsByDepth.get(d.circuit_length).push(d.success_probability);
+  }
+  const pct = (arr, q) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    const idx = q * (sorted.length - 1);
+    const lo = Math.floor(idx), hi = Math.ceil(idx);
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+  };
+  const tipData = [...statsByDepth.entries()].map(([length, vals]) => {
+    const q1 = pct(vals, 0.25), q3 = pct(vals, 0.75);
+    const iqr = q3 - q1;
+    const sorted = [...vals].sort((a, b) => a - b);
+    // Whisker = range of non-outlier data (within 1.5×IQR of Q1/Q3)
+    const whiskerLo = sorted.find(v => v >= q1 - 1.5 * iqr) ?? sorted[0];
+    const whiskerHi = [...sorted].reverse().find(v => v <= q3 + 1.5 * iqr) ?? sorted[sorted.length - 1];
+    return {length, median: pct(vals, 0.5), q1, q3, whiskerLo, whiskerHi, n: vals.length};
+  });
+
+  const chart = Plot.plot({
     width,
-    height: 280,
+    height: 300,
     marginLeft: 55,
+    marginBottom: 40,
     x: {label: "Circuit depth (# CNOTs)", tickFormat: d => `${d}`},
     y: {
       domain: [DOMAIN_FLOOR, 1.02],
@@ -99,11 +128,45 @@ export function boxByLength(data, {color = "#363D47", width = 560} = {}) {
         x: "circuit_length",
         y: "success_probability",
         fill: color,
-        fillOpacity: 0.3,
+        fillOpacity: 0.6,
         stroke: color,
+        clip: "frame",
+      }),
+      // Invisible dots at median for tooltip
+      Plot.dot(tipData, {
+        x: "length",
+        y: "median",
+        r: 8,
+        fillOpacity: 0,
+        strokeOpacity: 0,
+        tip: true,
+        title: d =>
+          `Depth ${d.length}  (${d.n} circuits)\n` +
+          `Median   ${(d.median * 100).toFixed(1)}%\n` +
+          `IQR      ${(d.q1 * 100).toFixed(1)}% – ${(d.q3 * 100).toFixed(1)}%\n` +
+          `Whisker  ${(d.whiskerLo * 100).toFixed(1)}% – ${(d.whiskerHi * 100).toFixed(1)}%`,
       }),
     ],
   });
+
+  const s = `font-size:0.72rem;color:#74737B;display:flex;gap:1.25rem;flex-wrap:wrap;margin-top:0.4rem;align-items:center`;
+  const box = `display:inline-block;width:14px;height:10px;background:${color};opacity:0.6;border:1px solid ${color};vertical-align:middle;margin-right:4px`;
+  const line = `display:inline-block;width:1px;height:14px;background:${color};vertical-align:middle;margin-right:6px`;
+  const tick = `display:inline-block;width:10px;height:2px;background:${color};vertical-align:middle;margin-right:4px`;
+  const dot = `display:inline-block;width:7px;height:7px;border-radius:50%;border:1.5px solid ${color};vertical-align:middle;margin-right:4px`;
+
+  const legend = document.createElement("div");
+  legend.style.cssText = s;
+  legend.innerHTML =
+    `<span><span style="${box}"></span>IQR (middle 50%)</span>` +
+    `<span><span style="${line}"></span>Whisker (non-outlier range)</span>` +
+    `<span><span style="${tick}"></span>Median</span>` +
+    `<span><span style="${dot}"></span>Outlier</span>`;
+
+  const container = document.createElement("div");
+  container.appendChild(chart);
+  container.appendChild(legend);
+  return container;
 }
 
 /**
@@ -146,7 +209,7 @@ export function successByInput(data, {color = "#363D47", width = 400} = {}) {
     width,
     height: 260,
     marginLeft: 55,
-    x: {label: "Input state"},
+    x: {label: "Input state", domain: ["00", "01", "10", "11"]},
     y: {
       domain: [DOMAIN_FLOOR, 1.02],
       label: "Mean success probability",
@@ -169,44 +232,81 @@ export function successByInput(data, {color = "#363D47", width = 400} = {}) {
 }
 
 /**
- * Temporal drift scatter — per-circuit completion time vs success probability.
- * Reveals whether quality degrades or varies systematically within a run.
- * Color-coded by circuit depth.
+ * Rotatable 3D scatter — success probability as a function of circuit depth
+ * and input state. Point size encodes circuit count. Uses Plotly.js.
  */
-export function temporalDriftScatter(data, {width = 900} = {}) {
-  const circuits = data.circuits
-    .filter(d => d.job_end_time)
-    .map(d => ({...d, end_time: new Date(d.job_end_time)}));
+export async function successSurface3D(data, {height = 520} = {}) {
+  const Plotly = (await import("plotly.js-dist-min")).default;
 
-  if (circuits.length === 0) return html`<p style="color: var(--isc-muted)">No timestamp data available.</p>`;
+  const lengths = [1, 2, 3, 4, 5, 6];
+  const inputs = ["00", "01", "10", "11"];
 
-  return Plot.plot({
-    width,
-    height: 300,
-    marginLeft: 55,
-    y: {
-      domain: [DOMAIN_FLOOR, 1.02],
-      label: "Success probability",
-      tickFormat: d => `${(d * 100).toFixed(0)}%`,
+  // Aggregate mean success and count by (circuit_length, input_bits) across all runs
+  const sums = new Map();
+  const counts = new Map();
+  for (const d of data.circuits) {
+    const key = `${d.circuit_length},${d.input_bits}`;
+    sums.set(key, (sums.get(key) ?? 0) + d.success_probability);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const xs = [], ys = [], zs = [], ns = [];
+  for (const ib of inputs) {
+    for (const l of lengths) {
+      const key = `${l},${ib}`;
+      const n = counts.get(key) ?? 0;
+      if (n > 0) {
+        xs.push(l);
+        ys.push(ib);
+        zs.push(sums.get(key) / n);
+        ns.push(n);
+      }
+    }
+  }
+
+  const minN = Math.min(...ns);
+  const maxN = Math.max(...ns);
+  // Scale relative to actual min/max to maximise visible contrast
+  const sizes = ns.map(n => 5 + ((n - minN) / (maxN - minN || 1)) * 23);
+
+  const div = document.createElement("div");
+
+  await Plotly.newPlot(div, [{
+    type: "scatter3d",
+    mode: "markers",
+    x: xs,
+    y: ys,
+    z: zs,
+    text: ns.map(String),
+    marker: {
+      size: sizes,
+      color: zs,
+      colorscale: [[0, "#99979D"], [0.5, "#E7C89D"], [1, "#CC8A00"]],
+      cmin: 0.7,
+      cmax: 1.0,
+      colorbar: {
+        title: {text: "Success probability"},
+        tickformat: ".0%",
+        len: 0.6,
+      },
+      line: {width: 0},
     },
-    x: {type: "utc", label: "Circuit completion time"},
-    color: {
-      type: "ordinal",
-      domain: [1, 2, 3, 4, 5, 6],
-      label: "Circuit depth",
-      legend: true,
+    hovertemplate: "Depth %{x}<br>Input |%{y}⟩<br>Success %{z:.1%}<br>%{text} circuits<extra></extra>",
+  }], {
+    scene: {
+      xaxis: {title: {text: "Depth (# CNOTs)"}, dtick: 1},
+      yaxis: {title: {text: "Input state"}, type: "category", categoryorder: "array", categoryarray: ["00", "01", "10", "11"]},
+      zaxis: {title: {text: "Success probability"}, range: [0.7, 1.0], tickformat: ".0%"},
+      camera: {eye: {x: 1.6, y: -1.6, z: 0.8}},
     },
-    marks: [
-      Plot.ruleY([1], {stroke: "#e2e8f0", strokeDasharray: "4,4"}),
-      Plot.dot(circuits, {
-        x: "end_time",
-        y: "success_probability",
-        fill: "circuit_length",
-        r: 4,
-        fillOpacity: 0.7,
-        tip: true,
-        title: d => `Depth ${d.circuit_length} · |${d.input_bits}⟩\n${(d.success_probability * 100).toFixed(0)}%\n${d.run_date}`,
-      }),
-    ],
-  });
+    margin: {l: 0, r: 0, b: 0, t: 0},
+    height,
+  }, {responsive: true, displayModeBar: false, scrollZoom: false});
+
+  const clip = 80;
+  const outer = document.createElement("div");
+  outer.style.cssText = `overflow: hidden; height: ${height - clip}px;`;
+  div.style.marginTop = `-${clip}px`;
+  outer.appendChild(div);
+  return outer;
 }

--- a/dashboard/src/data/ionq.json.py
+++ b/dashboard/src/data/ionq.json.py
@@ -1,5 +1,5 @@
 """
-Data loader: IonQ results (Aria-1 historical via Braket + Forte-1 direct 2025 runs).
+Data loader: IonQ Aria-1 results.
 """
 import json
 import sys
@@ -15,9 +15,10 @@ if not csv_path.exists():
     sys.exit(0)
 
 df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
-# Exclude simulator/dry-run rows and Harmony (older lower-fidelity hardware)
-df = df[~df["notes"].fillna("").isin(["dry_run", "simulator"])]
-df = df[df["backend"].isin(["Aria-1", "Forte-1"])]
+df = df[df["notes"].fillna("") == ""]
+
+# IonQ data includes Harmony + Aria-1 — keep only Aria-1 for consistency
+df = df[df["backend"].str.contains("Aria", na=False)]
 
 runs = (
     df.groupby("run_date")["success_probability"]
@@ -47,7 +48,7 @@ by_input = (
 
 output = {
     "platform": "ionq",
-    "backend": "Aria-1 / Forte-1",
+    "backend": "Aria-1",
     "runs": runs.to_dict(orient="records"),
     "circuits": circuits.to_dict(orient="records"),
     "by_length": by_length.to_dict(orient="records"),

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -10,36 +10,32 @@ import pandas as pd
 repo_root = Path(__file__).parents[3]
 
 PLATFORMS = {
-    "rigetti": {"backend": "Ankaa-3", "status": "active",     "cost_per_run_usd": 3.90},
-    "aqt":     {"backend": "IBEX",    "status": "active",     "cost_per_run_usd": 25.07},
-    "ionq":    {"backend": "Forte-1", "status": "historical", "cost_per_run_usd": 33.00},
+    "aqt":        {"backend": "IBEX",    "status": "active",     "cost_per_run_usd": 25.07},
+    "ionq":       {"backend": "Aria-1",  "status": "historical", "cost_per_run_usd": 33.00,  "csv_key": "ionq", "backend_filter": "Aria"},
+    "ionq_forte": {"backend": "Forte-1", "status": "historical", "cost_per_run_usd": 259.00, "csv_key": "ionq", "backend_filter": "Forte"},
+    "rigetti":    {"backend": "Ankaa-3", "status": "active",     "cost_per_run_usd": 3.90},
 }
 
 summary = []
 
 for platform, meta in PLATFORMS.items():
-    csv_path = repo_root / "data" / platform / "results.csv"
+    csv_key = meta.get("csv_key", platform)
+    csv_path = repo_root / "data" / csv_key / "results.csv"
     if not csv_path.exists():
         summary.append({
-            "platform": platform,
-            "backend": meta["backend"],
-            "status": meta["status"],
+            "platform": platform, "backend": meta["backend"], "status": meta["status"],
             "cost_per_run_usd": meta["cost_per_run_usd"],
-            "latest_run": None,
-            "latest_success": None,
-            "overall_mean": None,
-            "n_runs": 0,
-            "n_circuits": 0,
-            "sparkline": [],
+            "latest_run": None, "latest_success": None, "overall_mean": None,
+            "n_runs": 0, "n_circuits": 0, "sparkline": [],
         })
         continue
 
     df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
-    # Exclude simulator/dry-run rows
-    df = df[~df["notes"].fillna("").isin(["dry_run", "simulator"])]
+    df = df[df["notes"].fillna("") == ""]
 
-    if platform == "ionq":
-        df = df[df["backend"].isin(["Aria-1", "Forte-1"])]
+    backend_filter = meta.get("backend_filter")
+    if backend_filter:
+        df = df[df["backend"].str.contains(backend_filter, na=False)]
 
     if df.empty:
         summary.append({
@@ -57,13 +53,18 @@ for platform, meta in PLATFORMS.items():
 
     runs = (
         df.groupby("run_date")["success_probability"]
-        .mean()
+        .agg(success_probability="mean", std_success="std")
         .reset_index()
         .sort_values("run_date")
     )
+    runs["std_success"] = runs["std_success"].fillna(0.0)
 
     sparkline = [
-        {"date": row["run_date"].strftime("%Y-%m-%d"), "value": round(row["success_probability"], 4)}
+        {
+            "date": row["run_date"].strftime("%Y-%m-%d"),
+            "value": round(float(row["success_probability"]), 4),
+            "std": round(float(row["std_success"]), 4),
+        }
         for _, row in runs.iterrows()
     ]
 

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -36,35 +36,65 @@ ${summary.map(p => html`
 `)}
 </div>
 
-## Success probability over time
+## Consistency over time
+
+Within-run standard deviation per run — lower is more consistent.
 
 ```js
+const PLATFORM_LABEL = {aqt: "AQT IBEX", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Ankaa-3"};
+const PLATFORM_COLOR = {aqt: "#363D47", ionq: "#74737B", ionq_forte: "#99979D", rigetti: "#CC8A00"};
 const allRuns = summary.flatMap(p =>
-  p.sparkline.map(d => ({...d, platform: p.platform, date: new Date(d.date)}))
+  p.sparkline.map(d => ({...d, label: PLATFORM_LABEL[p.platform] ?? p.platform, date: new Date(d.date)}))
 );
-const platformColors = {rigetti: "#CC8A00", aqt: "#363D47", ionq: "#74737B"};
+const volatilityRuns = allRuns.filter(d => d.std > 0);
+const colorDomain = Object.values(PLATFORM_LABEL);
+const colorRange  = Object.values(PLATFORM_COLOR);
 ```
 
 ```js
 Plot.plot({
   width: 900,
+  height: 220,
+  marginLeft: 55,
+  y: {label: "Within-run std dev", tickFormat: d => `${(d * 100).toFixed(1)}%`},
+  x: {type: "utc", label: null},
+  color: {domain: colorDomain, range: colorRange, legend: true},
+  marks: [
+    Plot.line(volatilityRuns, {
+      x: "date", y: "std", stroke: "label",
+      strokeWidth: 1.5, curve: "monotone-x",
+    }),
+    Plot.dot(volatilityRuns, {
+      x: "date", y: "std", fill: "label",
+      r: 3, tip: true,
+      title: d => `${d.label}\n${d.date.toLocaleDateString()}\nσ = ${(d.std * 100).toFixed(1)}%`,
+    }),
+  ],
+})
+```
+
+## Success probability over time
+
+```js
+Plot.plot({
+  width: 900,
   height: 280,
-  marginLeft: 50,
+  marginLeft: 55,
   y: {domain: [0.7, 1.02], label: "Mean success probability", tickFormat: d => `${(d*100).toFixed(0)}%`},
   x: {type: "utc", label: null},
-  color: {domain: Object.keys(platformColors), range: Object.values(platformColors), legend: true},
+  color: {domain: colorDomain, range: colorRange, legend: true},
   marks: [
     Plot.ruleY([1], {stroke: "#e2e8f0"}),
     Plot.line(allRuns, {
-      x: "date", y: "value", stroke: "platform",
-      strokeWidth: 2, curve: "monotone-x"
+      x: "date", y: "value", stroke: "label",
+      strokeWidth: 2, curve: "monotone-x",
     }),
     Plot.dot(allRuns, {
-      x: "date", y: "value", fill: "platform",
+      x: "date", y: "value", fill: "label",
       r: 3, tip: true,
-      title: d => `${d.platform}\n${d.date.toLocaleDateString()}\n${(d.value * 100).toFixed(1)}%`
+      title: d => `${d.label}\n${d.date.toLocaleDateString()}\n${(d.value * 100).toFixed(1)}%`,
     }),
-  ]
+  ],
 })
 ```
 
@@ -73,23 +103,27 @@ Plot.plot({
 10 circuits × 100 shots. Pricing as of April 2026.
 
 ```js
+const PLATFORM_NAME = {
+  aqt: "AQT IBEX (direct)", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Ankaa-3",
+};
+const ACCESS = {
+  aqt: "qiskit-aqt-provider", ionq: "AWS Braket (historical)",
+  ionq_forte: "IonQ REST API (historical)", rigetti: "AWS Braket",
+};
 const costRows = [
   ...summary.map(p => ({
-    platform: p.platform === "rigetti" ? "Rigetti Ankaa-3" :
-              p.platform === "aqt"     ? "AQT IBEX" :
-                                         "IonQ Aria-1",
-    access: p.platform === "rigetti" ? "AWS Braket" :
-            p.platform === "aqt"     ? "qiskit-aqt-provider (direct)" :
-                                       "AWS Braket (historical)",
+    platform: PLATFORM_NAME[p.platform] ?? p.platform,
+    access: ACCESS[p.platform] ?? "—",
     cost_per_run: p.cost_per_run_usd,
     annual_52: p.cost_per_run_usd * 52,
   })),
-  {platform: "AQT IBEX (alt)", access: "AWS Braket", cost_per_run: 26.50, annual_52: 26.50 * 52},
+  {platform: "AQT IBEX (via Braket)", access: "AWS Braket", cost_per_run: 26.50, annual_52: 26.50 * 52},
 ];
 ```
 
 ```js
-Inputs.table(costRows, {
+Inputs.table(costRows.sort((a, b) => a.platform.localeCompare(b.platform)), {
+  select: false,
   columns: ["platform", "access", "cost_per_run", "annual_52"],
   header: {platform: "Platform", access: "Access", cost_per_run: "Per run", annual_52: "Annual (52×)"},
   format: {
@@ -99,8 +133,10 @@ Inputs.table(costRows, {
 })
 ```
 
-*AQT pricing from quotation Q2511001 (Nov 2025), converted at EUR/USD ≈ 1.09. "AQT IBEX (alt)" is the AWS Braket-managed access path — within ~5% of direct, slightly more expensive. IonQ figure is historical (Aria-1 at $0.03/shot); current Forte would be ~$83/run.*
+*AQT pricing from quotation Q2511001 (Nov 2025), converted at EUR/USD ≈ 1.09. IonQ figure is historical (Aria-1 at $0.03/shot); current Forte would be ~$83/run.*
 
 ---
 
-*Benchmarks run weekly. Each run samples 10 circuits from a family of 24 (6 circuit depths × 4 input states), 100 shots each. [Learn more about the methodology.](/about)*
+*Benchmarks run weekly. Each run samples 10 circuits from a family of 24 (6 circuit depths × 4 input states), 100 shots each.*
+
+<a href="/about" style="display:inline-block;margin-top:0.25rem;font-size:0.9rem;color:var(--isc-gold);font-weight:600;text-decoration:none;border-bottom:1.5px solid var(--isc-gold)">Learn more about the methodology →</a>

--- a/dashboard/src/ionq.md
+++ b/dashboard/src/ionq.md
@@ -1,15 +1,15 @@
 ---
-title: IonQ
+title: IonQ Aria-1
 ---
 
 ```js
-import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, temporalDriftScatter} from "./components/platformCharts.js";
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
 const data = await FileAttachment("data/ionq.json").json();
 ```
 
-# IonQ
+# IonQ Aria-1
 
-Trapped-ion QPU benchmarks run directly via the IonQ API. Data covers two hardware generations: **Aria-1** (accessed via AWS Braket, February–March 2024) and **Forte-1** (accessed directly, May–June 2025). Runs are currently paused.
+Trapped-ion QPU accessed via AWS Braket. Historical data from February–March 2024. Runs are currently paused.
 
 <div style="display: flex; gap: 2rem; margin: 1rem 0;">
   <div class="platform-card" style="flex: 1">
@@ -18,7 +18,7 @@ Trapped-ion QPU benchmarks run directly via the IonQ API. Data covers two hardwa
   </div>
   <div class="platform-card" style="flex: 1">
     <div class="metric">${data.runs.length}</div>
-    <div class="metric-label">Total runs</div>
+    <div class="metric-label">Runs (2024)</div>
   </div>
   <div class="platform-card" style="flex: 1">
     <div class="metric">${data.circuits.length}</div>
@@ -26,37 +26,49 @@ Trapped-ion QPU benchmarks run directly via the IonQ API. Data covers two hardwa
   </div>
 </div>
 
-## Success probability over time
-
-Each point is the mean success rate across the circuits sampled that week. The shaded band shows ±1 standard deviation within the run.
-
-```js
-successTimeSeries(data, {color: "#74737B"})
-```
-
 ## Consistency over time
 
-Within-run standard deviation per week. Lower is more consistent.
+Within-run standard deviation per run — the primary stability metric for this benchmark. Lower is more consistent.
 
 ```js
 volatilityTimeSeries(data, {color: "#74737B"})
 ```
 
-## Distribution by circuit depth
+## Success probability over time
 
-Box plots show the full distribution — median (center line), interquartile range (box), and outliers (dots). Wider boxes and lower medians at higher depths indicate noise accumulation with circuit complexity.
+Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the circuits sampled that run. The shaded band shows ±1 standard deviation within the run.
+
+```js
+successTimeSeries(data, {color: "#74737B"})
+```
+
+## Performance breakdown
+
+How success probability varies across circuit depth and input state, aggregated across all runs.
+
+### Success probability by circuit depth and input state
+
+<p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
+
+```js
+successSurface3D(data)
+```
+
+### Distribution by circuit depth
 
 ```js
 boxByLength(data, {color: "#74737B"})
 ```
 
-## Mean success by circuit depth
+### Mean success by circuit depth
+
+Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
 
 ```js
 successByLength(data, {color: "#74737B"})
 ```
 
-## Mean success by input state
+### Mean success by input state
 
 Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
 
@@ -64,18 +76,11 @@ Does the initial qubit state affect results? Ideally it shouldn't — deviations
 successByInput(data, {color: "#74737B"})
 ```
 
-## Temporal drift within runs
-
-Per-circuit completion time vs. success probability, colored by circuit depth. Systematic patterns indicate hardware drift during execution.
-
-```js
-temporalDriftScatter(data)
-```
-
 ## All runs
 
 ```js
 Inputs.table(data.runs.slice().reverse(), {
+  select: false,
   columns: ["run_date", "mean_success", "std_success", "n_circuits"],
   header: {
     run_date: "Date",

--- a/dashboard/src/rigetti.md
+++ b/dashboard/src/rigetti.md
@@ -3,7 +3,7 @@ title: Rigetti Ankaa-3
 ---
 
 ```js
-import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, temporalDriftScatter} from "./components/platformCharts.js";
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
 const data = await FileAttachment("data/rigetti.json").json();
 ```
 
@@ -30,37 +30,49 @@ Superconducting QPU accessed via AWS Braket. Runs weekly on Tuesdays.
   </div>
 </div>
 
-## Success probability over time
-
-Each point is the mean success rate across the 10 circuits sampled that week. The shaded band shows ±1 standard deviation within the run.
-
-```js
-successTimeSeries(data, {color: "#CC8A00"})
-```
-
 ## Consistency over time
 
-Within-run standard deviation per week. Lower is more consistent. Upward trend indicates growing variability.
+Within-run standard deviation per week — the primary stability metric for this benchmark. Lower is more consistent; an upward trend indicates growing variability.
 
 ```js
 volatilityTimeSeries(data, {color: "#CC8A00"})
 ```
 
-## Distribution by circuit depth
+## Success probability over time
 
-Box plots show the full distribution — median (center line), interquartile range (box), and outliers (dots). Wider boxes and lower medians at higher depths indicate noise accumulation with circuit complexity.
+Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the 10 circuits sampled that week. The shaded band shows ±1 standard deviation within the run.
+
+```js
+successTimeSeries(data, {color: "#CC8A00"})
+```
+
+## Performance breakdown
+
+How success probability varies across circuit depth and input state, aggregated across all runs.
+
+### Success probability by circuit depth and input state
+
+<p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
+
+```js
+successSurface3D(data)
+```
+
+### Distribution by circuit depth
 
 ```js
 boxByLength(data, {color: "#CC8A00"})
 ```
 
-## Mean success by circuit depth
+### Mean success by circuit depth
+
+Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
 
 ```js
 successByLength(data, {color: "#CC8A00"})
 ```
 
-## Mean success by input state
+### Mean success by input state
 
 Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
 
@@ -68,18 +80,11 @@ Does the initial qubit state affect results? Ideally it shouldn't — deviations
 successByInput(data, {color: "#CC8A00"})
 ```
 
-## Temporal drift within runs
-
-Per-circuit completion time vs. success probability, colored by circuit depth. Systematic patterns (e.g., quality worsening over time within a run) indicate hardware drift during execution.
-
-```js
-temporalDriftScatter(data)
-```
-
 ## All runs
 
 ```js
 Inputs.table(data.runs.slice().reverse(), {
+  select: false,
   columns: ["run_date", "mean_success", "std_success", "n_circuits"],
   header: {
     run_date: "Date",

--- a/dashboard/src/theme.css
+++ b/dashboard/src/theme.css
@@ -159,6 +159,14 @@ code, pre, .mono {
 .badge-historical { background: var(--isc-blue-20);   color: var(--isc-dark-blue); }
 
 /* ==========================================================================
+   Data table — row hover highlight, no selection chrome
+   ========================================================================== */
+
+.observablehq tbody tr:hover td {
+  background: var(--isc-gray-40);
+}
+
+/* ==========================================================================
    Footer
    ========================================================================== */
 
@@ -167,4 +175,5 @@ code, pre, .mono {
   font-size: 0.75rem;
   color: var(--isc-muted);
   border-top: 1px solid var(--isc-border);
+  padding-top: 1rem;
 }

--- a/scripts/submit_benchmark.py
+++ b/scripts/submit_benchmark.py
@@ -24,10 +24,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 ENABLED_PLATFORMS = [
     "rigetti_braket",  # active: Rigetti Ankaa-3 via AWS Braket (us-west-1)
     "aqt_qiskit",      # active: AQT via qiskit-aqt-provider; requires AQT_API_KEY secret
-    "ibm_qiskit",      # active: IBM Brisbane via Qiskit Runtime; requires IBM_QUANTUM_TOKEN secret
-    # "ionq_direct",   # active: IonQ Forte-1 via REST API — runs monthly via submit-benchmark-ionq.yml
-    # "ionq_braket",   # active: IonQ Forte-1 via AWS Braket — runs monthly via submit-benchmark-ionq-braket.yml
-    # "iqm_braket",    # active: IQM Garnet via AWS Braket — runs weekly via submit-benchmark-iqm.yml
+    # "ionq_braket",   # paused: budget
+    # "ibm_qiskit",    # pending: locate Sami's notebook and existing results
 ]
 
 
@@ -68,6 +66,7 @@ def main() -> None:
     print(f"Submitting benchmarks for: {platforms}")
     print(f"Run date: {run_date}  |  Mode: {mode}")
 
+    failed = []
     for platform_name in platforms:
         print(f"\n=== {platform_name} ===")
         try:
@@ -85,7 +84,11 @@ def main() -> None:
 
         except Exception as e:
             print(f"  ERROR: {e}")
-            raise
+            failed.append(platform_name)
+
+    if failed:
+        print(f"\nFailed platforms: {failed}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-dashboard.yml` to build and deploy the Observable Framework dashboard to GitHub Pages
- Triggers automatically on pushes to `main` that touch `dashboard/**` or `data/**` (so it redeploys when new benchmark data lands)
- Also supports manual `workflow_dispatch` runs from the Actions tab

## How it works

1. **Build job**: installs uv + Python deps, activates the venv so data loaders (`.json.py` files) can import pandas, installs Node deps, runs `observable build` → `dashboard/dist/`
2. **Deploy job**: uploads `dist/` artifact and deploys to GitHub Pages via `actions/deploy-pages@v4`

## Before merging

Enable GitHub Pages in the repo settings:
- `Settings → Pages → Source → GitHub Actions`