### PR TITLE
ci: deploy dashboard to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,0 +1,74 @@
+name: Deploy Dashboard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "dashboard/**"
+      - "data/**"
+      - ".github/workflows/deploy-dashboard.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    name: Build dashboard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install Node dependencies
+        working-directory: dashboard
+        run: npm ci
+
+      - name: Build
+        working-directory: dashboard
+        run: |
+          source ../.venv/bin/activate
+          npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboard/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-dashboard.yml` to build and deploy the Observable Framework dashboard to GitHub Pages
- Triggers automatically on pushes to `main` that touch `dashboard/**` or `data/**` (so it redeploys when new benchmark data lands)
- Also supports manual `workflow_dispatch` runs from the Actions tab

## How it works

1. **Build job**: installs uv + Python deps, activates the venv so data loaders (`.json.py` files) can import pandas, installs Node deps, runs `observable build` → `dashboard/dist/`
2. **Deploy job**: uploads `dist/` artifact and deploys to GitHub Pages via `actions/deploy-pages@v4`

## Before merging

Enable GitHub Pages in the repo settings:
- `Settings → Pages → Source → GitHub Actions`