### PR TITLE
dashboard: add blog posts and partners to About ISC page

### DIFF
--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -7,6 +7,7 @@ export default {
       name: "Platforms",
       pages: [
         {name: "AQT IBEX", path: "/aqt"},
+        {name: "IBM Brisbane", path: "/ibm"},
         {name: "IonQ Aria-1", path: "/ionq"},
         {name: "Rigetti Ankaa-3", path: "/rigetti"},
       ]

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -9,6 +9,7 @@ export default {
         {name: "AQT IBEX", path: "/aqt"},
         {name: "IBM Brisbane", path: "/ibm"},
         {name: "IonQ Aria-1", path: "/ionq"},
+        {name: "IonQ Forte-1", path: "/ionq-forte"},
         {name: "Rigetti Ankaa-3", path: "/rigetti"},
       ]
     },

--- a/dashboard/src/about-isc.md
+++ b/dashboard/src/about-isc.md
@@ -8,6 +8,22 @@ title: About Insight Softmax
 
 The Quantum Stability Monitor is one of our open research initiatives — a longitudinal benchmarking program that tracks the real-world reliability of quantum hardware over time. Rather than one-off performance snapshots, we run the same circuits weekly on each platform and ask: *is this hardware getting more or less consistent?*
 
+## Past quantum work
+
+- [Case study: Using quantum annealing and gate-model algorithms to cut costs and accelerate time to insight](https://insightsoftmax.com/blog/case-study-using-quantum-annealing-and-gate-model-algorithms-to-cut-costs-and-accelerate-time-to-insight)
+- [Conquering the noise: How we overcame variability in large-scale runs of Braket's IonQ service](https://insightsoftmax.com/blog/conquering-the-noise-how-we-overcame-variability-in-large-scale-runs-of-brakets-ionq-service)
+
+## Partners & platforms
+
+- [Anzaetek](https://anzaetek.com/)
+- [AQT](https://www.aqt.eu/)
+- [AWS Braket](https://aws.amazon.com/braket/)
+- [IonQ](https://ionq.com/)
+- [Marqov](https://www.marqov.ai/)
+- [Q-CTRL](https://q-ctrl.com/)
+- [QOSF](https://qosf.org/)
+- [QuantWare](https://www.quantware.eu/)
+
 ## Get in touch
 
 If you're interested in quantum benchmarking, reliability research, or working with us:

--- a/dashboard/src/components/platformCharts.js
+++ b/dashboard/src/components/platformCharts.js
@@ -235,7 +235,7 @@ export function successByInput(data, {color = "#363D47", width = 400} = {}) {
  * Rotatable 3D scatter — success probability as a function of circuit depth
  * and input state. Point size encodes circuit count. Uses Plotly.js.
  */
-export async function successSurface3D(data, {height = 520} = {}) {
+export async function successSurface3D(data, {height = 520, color = "#CC8A00"} = {}) {
   const Plotly = (await import("plotly.js-dist-min")).default;
 
   const lengths = [1, 2, 3, 4, 5, 6];
@@ -281,7 +281,7 @@ export async function successSurface3D(data, {height = 520} = {}) {
     marker: {
       size: sizes,
       color: zs,
-      colorscale: [[0, "#99979D"], [0.5, "#E7C89D"], [1, "#CC8A00"]],
+      colorscale: [[0, "#cccccc"], [1, color]],
       cmin: 0.7,
       cmax: 1.0,
       colorbar: {

--- a/dashboard/src/data/ibm.json.py
+++ b/dashboard/src/data/ibm.json.py
@@ -34,6 +34,7 @@ runs["std_success"] = runs["std_success"].fillna(0).round(4)
 # Per-circuit detail (for breakdowns)
 circuits = df[["run_date", "input_bits", "circuit_length", "success_probability", "job_end_time"]].copy()
 circuits["run_date"] = circuits["run_date"].dt.strftime("%Y-%m-%d")
+circuits = circuits.astype(object).where(pd.notnull(circuits), None)
 
 # Aggregated by circuit length
 by_length = (

--- a/dashboard/src/data/ionq-forte.json.py
+++ b/dashboard/src/data/ionq-forte.json.py
@@ -1,5 +1,5 @@
 """
-Data loader: IonQ Aria-1 results.
+Data loader: IonQ Forte-1 results.
 """
 import json
 import sys
@@ -16,9 +16,7 @@ if not csv_path.exists():
 
 df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
 df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
-
-# IonQ data includes Harmony + Aria-1 — keep only Aria-1 for consistency
-df = df[df["backend"].str.contains("Aria", na=False)]
+df = df[df["backend"].str.contains("Forte", na=False)]
 
 runs = (
     df.groupby("run_date")["success_probability"]
@@ -48,8 +46,8 @@ by_input = (
 ).round(4)
 
 output = {
-    "platform": "ionq",
-    "backend": "Aria-1",
+    "platform": "ionq_forte",
+    "backend": "Forte-1",
     "runs": runs.to_dict(orient="records"),
     "circuits": circuits.to_dict(orient="records"),
     "by_length": by_length.to_dict(orient="records"),

--- a/dashboard/src/data/ionq.json.py
+++ b/dashboard/src/data/ionq.json.py
@@ -15,7 +15,7 @@ if not csv_path.exists():
     sys.exit(0)
 
 df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
-df = df[df["notes"].fillna("") == ""]
+df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
 
 # IonQ data includes Harmony + Aria-1 — keep only Aria-1 for consistency
 df = df[df["backend"].str.contains("Aria", na=False)]

--- a/dashboard/src/data/rigetti.json.py
+++ b/dashboard/src/data/rigetti.json.py
@@ -18,7 +18,7 @@ if not csv_path.exists():
 df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
 
 # Exclude simulator/dry-run rows
-df = df[df["notes"].fillna("") == ""]
+df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
 
 # Per-run aggregates (one row per run_date)
 runs = (

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -32,7 +32,7 @@ for platform, meta in PLATFORMS.items():
         continue
 
     df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
-    df = df[df["notes"].fillna("") == ""]
+    df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
 
     backend_filter = meta.get("backend_filter")
     if backend_filter:

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -10,10 +10,11 @@ import pandas as pd
 repo_root = Path(__file__).parents[3]
 
 PLATFORMS = {
-    "aqt":        {"backend": "IBEX",    "status": "active",     "cost_per_run_usd": 25.07},
-    "ionq":       {"backend": "Aria-1",  "status": "historical", "cost_per_run_usd": 33.00,  "csv_key": "ionq", "backend_filter": "Aria"},
-    "ionq_forte": {"backend": "Forte-1", "status": "historical", "cost_per_run_usd": 259.00, "csv_key": "ionq", "backend_filter": "Forte"},
-    "rigetti":    {"backend": "Ankaa-3", "status": "active",     "cost_per_run_usd": 3.90},
+    "aqt":        {"backend": "IBEX",     "status": "active",     "cost_per_run_usd": 25.07},
+    "ibm":        {"backend": "Brisbane", "status": "historical", "cost_per_run_usd": None},
+    "ionq":       {"backend": "Aria-1",   "status": "historical", "cost_per_run_usd": 33.00,  "csv_key": "ionq", "backend_filter": "Aria"},
+    "ionq_forte": {"backend": "Forte-1",  "status": "historical", "cost_per_run_usd": 259.00, "csv_key": "ionq", "backend_filter": "Forte"},
+    "rigetti":    {"backend": "Ankaa-3",  "status": "active",     "cost_per_run_usd": 3.90},
 }
 
 summary = []

--- a/dashboard/src/ibm.md
+++ b/dashboard/src/ibm.md
@@ -55,7 +55,7 @@ How success probability varies across circuit depth and input state, aggregated 
 <p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
 
 ```js
-successSurface3D(data)
+successSurface3D(data, {color: "#1192E8"})
 ```
 
 ### Distribution by circuit depth

--- a/dashboard/src/ibm.md
+++ b/dashboard/src/ibm.md
@@ -3,7 +3,7 @@ title: IBM Brisbane
 ---
 
 ```js
-import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, temporalDriftScatter} from "./components/platformCharts.js";
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D, temporalDriftScatter} from "./components/platformCharts.js";
 const data = await FileAttachment("data/ibm.json").json();
 ```
 
@@ -30,31 +30,41 @@ Superconducting QPU (Eagle r3, 127 qubits) accessed via Qiskit Runtime. Historic
   </div>
 </div>
 
-## Success probability over time
-
-Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across all circuits sampled in that run. The shaded band shows ±1 standard deviation within the run.
-
-```js
-successTimeSeries(data, {color: "#1192E8"})
-```
-
 ## Consistency over time
 
-Within-run standard deviation per run. Lower is more consistent.
+Within-run standard deviation per run — the primary stability metric for this benchmark. Lower is more consistent.
 
 ```js
 volatilityTimeSeries(data, {color: "#1192E8"})
 ```
 
-## Distribution by circuit depth
+## Success probability over time
 
-Box plots show the full distribution — median (center line), interquartile range (box), and outliers (dots). Wider boxes and lower medians at higher depths indicate noise accumulation with circuit complexity.
+Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the circuits sampled that run. The shaded band shows ±1 standard deviation within the run.
+
+```js
+successTimeSeries(data, {color: "#1192E8"})
+```
+
+## Performance breakdown
+
+How success probability varies across circuit depth and input state, aggregated across all runs.
+
+### Success probability by circuit depth and input state
+
+<p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
+
+```js
+successSurface3D(data)
+```
+
+### Distribution by circuit depth
 
 ```js
 boxByLength(data, {color: "#1192E8"})
 ```
 
-## Mean success by circuit depth
+### Mean success by circuit depth
 
 Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
 
@@ -62,7 +72,7 @@ Mean success probability for each depth, averaged across all runs. A declining t
 successByLength(data, {color: "#1192E8"})
 ```
 
-## Mean success by input state
+### Mean success by input state
 
 Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
 
@@ -82,6 +92,7 @@ temporalDriftScatter(data)
 
 ```js
 Inputs.table(data.runs.slice().reverse(), {
+  select: false,
   columns: ["run_date", "mean_success", "std_success", "n_circuits"],
   header: {
     run_date: "Date",

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -22,6 +22,7 @@ ${summary.map(p => html`
     <div class="platform-name">
       ${p.platform === "rigetti" ? html`<a href="/rigetti">Rigetti ${p.backend}</a>` :
         p.platform === "aqt"     ? html`<a href="/aqt">AQT ${p.backend}</a>` :
+        p.platform === "ibm"     ? html`<a href="/ibm">IBM ${p.backend}</a>` :
                                    html`<a href="/ionq">IonQ ${p.backend}</a>`}
       <span class="badge ${statusClass[p.status]}" style="margin-left: 0.5rem">${statusLabel[p.status]}</span>
     </div>
@@ -41,8 +42,8 @@ ${summary.map(p => html`
 Within-run standard deviation per run — lower is more consistent.
 
 ```js
-const PLATFORM_LABEL = {aqt: "AQT IBEX", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Ankaa-3"};
-const PLATFORM_COLOR = {aqt: "#363D47", ionq: "#74737B", ionq_forte: "#99979D", rigetti: "#CC8A00"};
+const PLATFORM_LABEL = {aqt: "AQT IBEX", ibm: "IBM Brisbane", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Ankaa-3"};
+const PLATFORM_COLOR = {aqt: "#363D47", ibm: "#4A7FBB", ionq: "#74737B", ionq_forte: "#99979D", rigetti: "#CC8A00"};
 const allRuns = summary.flatMap(p =>
   p.sparkline.map(d => ({...d, label: PLATFORM_LABEL[p.platform] ?? p.platform, date: new Date(d.date)}))
 );
@@ -111,7 +112,7 @@ const ACCESS = {
   ionq_forte: "IonQ REST API (historical)", rigetti: "AWS Braket",
 };
 const costRows = [
-  ...summary.map(p => ({
+  ...summary.filter(p => p.cost_per_run_usd != null).map(p => ({
     platform: PLATFORM_NAME[p.platform] ?? p.platform,
     access: ACCESS[p.platform] ?? "—",
     cost_per_run: p.cost_per_run_usd,

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -22,8 +22,9 @@ ${summary.map(p => html`
     <div class="platform-name">
       ${p.platform === "rigetti" ? html`<a href="/rigetti">Rigetti ${p.backend}</a>` :
         p.platform === "aqt"     ? html`<a href="/aqt">AQT ${p.backend}</a>` :
-        p.platform === "ibm"     ? html`<a href="/ibm">IBM ${p.backend}</a>` :
-                                   html`<a href="/ionq">IonQ ${p.backend}</a>`}
+        p.platform === "ibm"          ? html`<a href="/ibm">IBM ${p.backend}</a>` :
+        p.platform === "ionq_forte"   ? html`<a href="/ionq-forte">IonQ ${p.backend}</a>` :
+                                        html`<a href="/ionq">IonQ ${p.backend}</a>`}
       <span class="badge ${statusClass[p.status]}" style="margin-left: 0.5rem">${statusLabel[p.status]}</span>
     </div>
     ${p.latest_success != null ? html`

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -44,7 +44,7 @@ Within-run standard deviation per run — lower is more consistent.
 
 ```js
 const PLATFORM_LABEL = {aqt: "AQT IBEX", ibm: "IBM Brisbane", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Ankaa-3"};
-const PLATFORM_COLOR = {aqt: "#363D47", ibm: "#4A7FBB", ionq: "#74737B", ionq_forte: "#99979D", rigetti: "#CC8A00"};
+const PLATFORM_COLOR = {aqt: "#363D47", ibm: "#1192E8", ionq: "#74737B", ionq_forte: "#99979D", rigetti: "#CC8A00"};
 const allRuns = summary.flatMap(p =>
   p.sparkline.map(d => ({...d, label: PLATFORM_LABEL[p.platform] ?? p.platform, date: new Date(d.date)}))
 );

--- a/dashboard/src/ionq-forte.md
+++ b/dashboard/src/ionq-forte.md
@@ -1,0 +1,96 @@
+---
+title: IonQ Forte-1
+---
+
+```js
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
+const data = await FileAttachment("data/ionq-forte.json").json();
+```
+
+# IonQ Forte-1
+
+Trapped-ion QPU accessed via the IonQ REST API. Historical data from May–June 2025. Runs are currently paused.
+
+<div style="display: flex; gap: 2rem; margin: 1rem 0;">
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${(data.runs.reduce((s, d) => s + d.mean_success, 0) / data.runs.length * 100).toFixed(1)}%</div>
+    <div class="metric-label">Historical mean</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length}</div>
+    <div class="metric-label">Runs (2025)</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.circuits.length}</div>
+    <div class="metric-label">Total circuits</div>
+  </div>
+</div>
+
+## Consistency over time
+
+Within-run standard deviation per run — the primary stability metric for this benchmark. Lower is more consistent.
+
+```js
+volatilityTimeSeries(data, {color: "#99979D"})
+```
+
+## Success probability over time
+
+Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the circuits sampled that run. The shaded band shows ±1 standard deviation within the run.
+
+```js
+successTimeSeries(data, {color: "#99979D"})
+```
+
+## Performance breakdown
+
+How success probability varies across circuit depth and input state, aggregated across all runs.
+
+### Success probability by circuit depth and input state
+
+<p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
+
+```js
+successSurface3D(data)
+```
+
+### Distribution by circuit depth
+
+```js
+boxByLength(data, {color: "#99979D"})
+```
+
+### Mean success by circuit depth
+
+Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
+
+```js
+successByLength(data, {color: "#99979D"})
+```
+
+### Mean success by input state
+
+Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
+
+```js
+successByInput(data, {color: "#99979D"})
+```
+
+## All runs
+
+```js
+Inputs.table(data.runs.slice().reverse(), {
+  select: false,
+  columns: ["run_date", "mean_success", "std_success", "n_circuits"],
+  header: {
+    run_date: "Date",
+    mean_success: "Mean success",
+    std_success: "Std dev",
+    n_circuits: "Circuits",
+  },
+  format: {
+    mean_success: d => `${(d * 100).toFixed(1)}%`,
+    std_success: d => `±${(d * 100).toFixed(1)}%`,
+  },
+})
+```

--- a/dashboard/src/ionq-forte.md
+++ b/dashboard/src/ionq-forte.md
@@ -51,7 +51,7 @@ How success probability varies across circuit depth and input state, aggregated 
 <p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
 
 ```js
-successSurface3D(data)
+successSurface3D(data, {color: "#99979D"})
 ```
 
 ### Distribution by circuit depth

--- a/dashboard/src/ionq.md
+++ b/dashboard/src/ionq.md
@@ -51,7 +51,7 @@ How success probability varies across circuit depth and input state, aggregated 
 <p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
 
 ```js
-successSurface3D(data)
+successSurface3D(data, {color: "#74737B"})
 ```
 
 ### Distribution by circuit depth

--- a/dashboard/src/rigetti.md
+++ b/dashboard/src/rigetti.md
@@ -55,7 +55,7 @@ How success probability varies across circuit depth and input state, aggregated 
 <p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
 
 ```js
-successSurface3D(data)
+successSurface3D(data, {color: "#CC8A00"})
 ```
 
 ### Distribution by circuit depth


### PR DESCRIPTION
Adds two sections to the About Insight Softmax page: past quantum blog posts and a linked list of partners/platforms.