### PR TITLE
chore: lint fixes, Node 24 deploy, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Python dependencies (uv-managed)
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      quantum-sdks:
+        patterns:
+          - "amazon-braket-*"
+          - "qiskit*"
+      data-science:
+        patterns:
+          - "pandas"
+          - "matplotlib"
+          - "seaborn"
+
+  # Dashboard npm dependencies
+  - package-ecosystem: npm
+    directory: "/dashboard"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: dashboard/package-lock.json
 

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -12,8 +12,10 @@ repo_root = Path(__file__).parents[3]
 PLATFORMS = {
     "aqt":        {"backend": "IBEX",     "status": "active",     "cost_per_run_usd": 25.07},
     "ibm":        {"backend": "Brisbane", "status": "historical", "cost_per_run_usd": None},
-    "ionq":       {"backend": "Aria-1",   "status": "historical", "cost_per_run_usd": 33.00,  "csv_key": "ionq", "backend_filter": "Aria"},
-    "ionq_forte": {"backend": "Forte-1",  "status": "historical", "cost_per_run_usd": 259.00, "csv_key": "ionq", "backend_filter": "Forte"},
+    "ionq":       {"backend": "Aria-1",  "status": "historical", "cost_per_run_usd": 33.00,
+                   "csv_key": "ionq", "backend_filter": "Aria"},
+    "ionq_forte": {"backend": "Forte-1", "status": "historical", "cost_per_run_usd": 259.00,
+                   "csv_key": "ionq", "backend_filter": "Forte"},
     "rigetti":    {"backend": "Ankaa-3",  "status": "active",     "cost_per_run_usd": 3.90},
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev-dependencies = [
 ]
 
 [tool.ruff]
-line-length = 100
+line-length = 120
 target-version = "py311"
 exclude = ["archive/"]
 

--- a/scripts/fetch_ionq_history.py
+++ b/scripts/fetch_ionq_history.py
@@ -25,7 +25,7 @@ import json
 import os
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import requests
@@ -60,13 +60,13 @@ def _api_get(key: str, path: str, params: dict | None = None) -> dict | list:
 def _ts_to_iso(unix_ts: int | float | None) -> str:
     if not unix_ts:
         return ""
-    return datetime.fromtimestamp(unix_ts, tz=timezone.utc).isoformat()
+    return datetime.fromtimestamp(unix_ts, tz=UTC).isoformat()
 
 
 def _ts_to_date(unix_ts: int | float | None) -> str:
     if not unix_ts:
         return ""
-    return datetime.fromtimestamp(unix_ts, tz=timezone.utc).date().isoformat()
+    return datetime.fromtimestamp(unix_ts, tz=UTC).date().isoformat()
 
 
 def _lsb_key_to_bits(key: str, n_qubits: int = 2) -> str:
@@ -178,16 +178,16 @@ def main() -> None:
 
     if args.explore:
         parent = parents[0]
-        print(f"\n--- Parent job (raw) ---")
+        print("\n--- Parent job (raw) ---")
         print(json.dumps(parent, indent=2))
         try:
             results = _api_get(key, f"/jobs/{parent['id']}/results")
-            print(f"\n--- Results (keyed by child ID) ---")
+            print("\n--- Results (keyed by child ID) ---")
             print(json.dumps(results, indent=2))
             full = _api_get(key, f"/jobs/{parent['id']}")
             children = full.get("children", [])
             if children:
-                print(f"\n--- First child job ---")
+                print("\n--- First child job ---")
                 child = _api_get(key, f"/jobs/{children[0]}")
                 print(json.dumps(child, indent=2))
         except Exception as e:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -35,7 +35,7 @@ def run_script(name: str, args: list[str], cwd: Path) -> subprocess.CompletedPro
 def append_results(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     # Re-import so the cwd-relative paths inside the function resolve to tmp_path
-    import importlib, sys
+    import sys
     sys.path.insert(0, str(REPO_ROOT))
     import scripts.collect_results as cr
     importlib.reload(cr)
@@ -184,6 +184,7 @@ def test_collect_still_waiting_keeps_pending_file(tmp_path):
     # Patch rigetti_braket.collect to return None (still waiting)
     with patch.dict("sys.modules", {}):
         import importlib
+
         import scripts.collect_results as cr
         importlib.reload(cr)
 
@@ -208,7 +209,6 @@ def test_collect_runtime_error_removes_pending_file(tmp_path):
         "input_bits": "00", "circuit_length": 1}],
     }))
 
-    import importlib
     import scripts.collect_results as cr
     importlib.reload(cr)
 


### PR DESCRIPTION
## Summary

- **Lint**: auto-fixed 10 issues (unused imports, f-strings without placeholders, import ordering, `timezone.utc` → `datetime.UTC`); bumped `line-length` to 120 to clear the remaining E501s on naturally-long lines (column name lists, assert messages)
- **Deploy workflow**: `node-version: 20 → 24` — eliminates the deprecation warning on every deploy run
- **Dependabot**: weekly PRs for Python deps (grouped by quantum SDKs and data-science), dashboard npm deps, and GitHub Actions — keeps the repo from going stale without any manual tracking

All 57 tests pass.