### PR TITLE
dashboard: split Rigetti Ankaa-3 / Cepheus; sort and group nav + cards

### DIFF
--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -4,13 +4,19 @@ export default {
   pages: [
     {name: "Overview", path: "/"},
     {
-      name: "Platforms",
+      name: "Active Platforms",
       pages: [
         {name: "AQT IBEX", path: "/aqt"},
+        {name: "Rigetti Cepheus-1-108Q", path: "/rigetti"},
+      ]
+    },
+    {
+      name: "Historical",
+      pages: [
         {name: "IBM Brisbane", path: "/ibm"},
         {name: "IonQ Aria-1", path: "/ionq"},
         {name: "IonQ Forte-1", path: "/ionq-forte"},
-        {name: "Rigetti Cepheus-1-108Q", path: "/rigetti"},
+        {name: "Rigetti Ankaa-3", path: "/rigetti-ankaa"},
       ]
     },
     {name: "Methodology", path: "/about"},

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -7,7 +7,7 @@ export default {
       name: "Active Platforms",
       pages: [
         {name: "AQT IBEX", path: "/aqt"},
-        {name: "Rigetti Cepheus-1-108Q", path: "/rigetti"},
+        {name: "Rigetti Cepheus-1-108Q", path: "/rigetti-cepheus"},
       ]
     },
     {

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -11,7 +11,7 @@ export default {
       ]
     },
     {
-      name: "Historical",
+      name: "Paused Platforms",
       pages: [
         {name: "IBM Brisbane", path: "/ibm"},
         {name: "IonQ Aria-1", path: "/ionq"},

--- a/dashboard/src/data/rigetti-ankaa.json.py
+++ b/dashboard/src/data/rigetti-ankaa.json.py
@@ -1,6 +1,6 @@
 """
-Data loader: Rigetti Cepheus-1-108Q results (from April 2026 onwards).
-Reads data/rigetti/results.csv and filters to Cepheus rows.
+Data loader: Rigetti Ankaa-3 historical results (through April 2026).
+Reads data/rigetti/results.csv and filters to Ankaa-3 rows.
 """
 import json
 import sys
@@ -17,9 +17,9 @@ if not csv_path.exists():
 
 df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
 
-# Exclude simulator/dry-run rows; filter to Cepheus device
+# Exclude simulator/dry-run rows; filter to Ankaa-3 device
 df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
-df = df[df["backend"].str.contains("Cepheus", na=False)]
+df = df[df["backend"].str.contains("Ankaa", na=False)]
 
 # Per-run aggregates (one row per run_date)
 runs = (
@@ -54,9 +54,8 @@ by_input = (
 by_input = by_input.round(4)
 
 output = {
-    "platform": "rigetti",
-    "backend": "Cepheus-1-108Q",
-    "platform": "rigetti_cepheus",
+    "platform": "rigetti_ankaa",
+    "backend": "Ankaa-3",
     "runs": runs.to_dict(orient="records"),
     "circuits": circuits.to_dict(orient="records"),
     "by_length": by_length.to_dict(orient="records"),

--- a/dashboard/src/data/rigetti-ankaa.json.py
+++ b/dashboard/src/data/rigetti-ankaa.json.py
@@ -43,6 +43,7 @@ by_length = (
     .reset_index()
     .rename(columns={"circuit_length": "length"})
 )
+by_length["std_success"] = by_length["std_success"].fillna(0)
 by_length = by_length.round(4)
 
 # Aggregated by input state
@@ -51,6 +52,7 @@ by_input = (
     .agg(mean_success="mean", std_success="std", n="count")
     .reset_index()
 )
+by_input["std_success"] = by_input["std_success"].fillna(0)
 by_input = by_input.round(4)
 
 output = {

--- a/dashboard/src/data/rigetti.json.py
+++ b/dashboard/src/data/rigetti.json.py
@@ -43,6 +43,7 @@ by_length = (
     .reset_index()
     .rename(columns={"circuit_length": "length"})
 )
+by_length["std_success"] = by_length["std_success"].fillna(0)
 by_length = by_length.round(4)
 
 # Aggregated by input state
@@ -51,12 +52,12 @@ by_input = (
     .agg(mean_success="mean", std_success="std", n="count")
     .reset_index()
 )
+by_input["std_success"] = by_input["std_success"].fillna(0)
 by_input = by_input.round(4)
 
 output = {
-    "platform": "rigetti",
-    "backend": "Cepheus-1-108Q",
     "platform": "rigetti_cepheus",
+    "backend": "Cepheus-1-108Q",
     "runs": runs.to_dict(orient="records"),
     "circuits": circuits.to_dict(orient="records"),
     "by_length": by_length.to_dict(orient="records"),

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -16,7 +16,10 @@ PLATFORMS = {
                    "csv_key": "ionq", "backend_filter": "Aria"},
     "ionq_forte": {"backend": "Forte-1", "status": "historical", "cost_per_run_usd": 259.00,
                    "csv_key": "ionq", "backend_filter": "Forte"},
-    "rigetti":    {"backend": "Cepheus-1-108Q", "status": "active",  "cost_per_run_usd": 3.43},
+    "rigetti_ankaa":   {"backend": "Ankaa-3",        "status": "historical", "cost_per_run_usd": 3.90,
+                        "csv_key": "rigetti", "backend_filter": "Ankaa"},
+    "rigetti_cepheus": {"backend": "Cepheus-1-108Q", "status": "active",    "cost_per_run_usd": 3.43,
+                        "csv_key": "rigetti", "backend_filter": "Cepheus"},
 }
 
 summary = []

--- a/dashboard/src/ibm.md
+++ b/dashboard/src/ibm.md
@@ -3,7 +3,7 @@ title: IBM Brisbane
 ---
 
 ```js
-import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D, temporalDriftScatter} from "./components/platformCharts.js";
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
 const data = await FileAttachment("data/ibm.json").json();
 ```
 
@@ -78,14 +78,6 @@ Does the initial qubit state affect results? Ideally it shouldn't — deviations
 
 ```js
 successByInput(data, {color: "#1192E8"})
-```
-
-## Temporal drift within runs
-
-Per-circuit completion time vs. success probability, colored by circuit depth. Systematic patterns indicate hardware drift during execution.
-
-```js
-temporalDriftScatter(data)
 ```
 
 ## All runs

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -14,18 +14,24 @@ const summary = await FileAttachment("data/summary.json").json();
 // Platform cards
 const statusLabel = {active: "Active", historical: "Paused", paused: "Paused"};
 const statusClass = {active: "badge-active", historical: "badge-historical", paused: "badge-paused"};
+const sortedSummary = [...summary].sort((a, b) => {
+  const order = s => s === "active" ? 0 : 1;
+  const so = order(a.status) - order(b.status);
+  return so !== 0 ? so : a.platform.localeCompare(b.platform);
+});
 ```
 
 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
-${summary.map(p => html`
+${sortedSummary.map(p => html`
   <div class="platform-card">
-    <div class="platform-name">
-      ${p.platform === "rigetti" ? html`<a href="/rigetti">Rigetti ${p.backend}</a>` :
-        p.platform === "aqt"     ? html`<a href="/aqt">AQT ${p.backend}</a>` :
-        p.platform === "ibm"          ? html`<a href="/ibm">IBM ${p.backend}</a>` :
-        p.platform === "ionq_forte"   ? html`<a href="/ionq-forte">IonQ ${p.backend}</a>` :
-                                        html`<a href="/ionq">IonQ ${p.backend}</a>`}
-      <span class="badge ${statusClass[p.status]}" style="margin-left: 0.5rem">${statusLabel[p.status]}</span>
+    <div class="platform-name" style="display:flex;flex-direction:column;align-items:flex-start;gap:0.35rem">
+      ${p.platform === "rigetti_cepheus" ? html`<a href="/rigetti">Rigetti ${p.backend}</a>` :
+        p.platform === "rigetti_ankaa"   ? html`<a href="/rigetti-ankaa">Rigetti ${p.backend}</a>` :
+        p.platform === "aqt"             ? html`<a href="/aqt">AQT ${p.backend}</a>` :
+        p.platform === "ibm"             ? html`<a href="/ibm">IBM ${p.backend}</a>` :
+        p.platform === "ionq_forte"      ? html`<a href="/ionq-forte">IonQ ${p.backend}</a>` :
+                                           html`<a href="/ionq">IonQ ${p.backend}</a>`}
+      <span class="badge ${statusClass[p.status]}">${statusLabel[p.status]}</span>
     </div>
     ${p.latest_success != null ? html`
       <div class="metric">${(p.latest_success * 100).toFixed(1)}%</div>
@@ -43,8 +49,16 @@ ${summary.map(p => html`
 Within-run standard deviation per run — lower is more consistent.
 
 ```js
-const PLATFORM_LABEL = {aqt: "AQT IBEX", ibm: "IBM Brisbane", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Cepheus-1-108Q"};
-const PLATFORM_COLOR = {aqt: "#363D47", ibm: "#1192E8", ionq: "#74737B", ionq_forte: "#99979D", rigetti: "#CC8A00"};
+const PLATFORM_LABEL = {
+  aqt: "AQT IBEX", ibm: "IBM Brisbane",
+  ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1",
+  rigetti_ankaa: "Rigetti Ankaa-3", rigetti_cepheus: "Rigetti Cepheus-1-108Q",
+};
+const PLATFORM_COLOR = {
+  aqt: "#363D47", ibm: "#1192E8",
+  ionq: "#74737B", ionq_forte: "#99979D",
+  rigetti_ankaa: "#A07800", rigetti_cepheus: "#CC8A00",
+};
 const allRuns = summary.flatMap(p =>
   p.sparkline.map(d => ({...d, label: PLATFORM_LABEL[p.platform] ?? p.platform, date: new Date(d.date)}))
 );
@@ -106,33 +120,58 @@ Plot.plot({
 
 ```js
 const PLATFORM_NAME = {
-  aqt: "AQT IBEX (direct)", ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1", rigetti: "Rigetti Cepheus-1-108Q",
+  aqt: "AQT IBEX (direct)", ibm: "IBM Brisbane",
+  ionq: "IonQ Aria-1", ionq_forte: "IonQ Forte-1",
+  rigetti_ankaa: "Rigetti Ankaa-3", rigetti_cepheus: "Rigetti Cepheus-1-108Q",
 };
 const ACCESS = {
-  aqt: "qiskit-aqt-provider", ionq: "AWS Braket (historical)",
-  ionq_forte: "IonQ REST API (historical)", rigetti: "AWS Braket",
+  aqt: "qiskit-aqt-provider", ibm: "Qiskit Runtime (historical)",
+  ionq: "AWS Braket (historical)", ionq_forte: "IonQ REST API (historical)",
+  rigetti_ankaa: "AWS Braket (historical)", rigetti_cepheus: "AWS Braket",
 };
 const costRows = [
   ...summary.filter(p => p.cost_per_run_usd != null).map(p => ({
     platform: PLATFORM_NAME[p.platform] ?? p.platform,
     access: ACCESS[p.platform] ?? "—",
+    status: p.status,
     cost_per_run: p.cost_per_run_usd,
     annual_52: p.cost_per_run_usd * 52,
   })),
-  {platform: "AQT IBEX (via Braket)", access: "AWS Braket", cost_per_run: 26.50, annual_52: 26.50 * 52},
+  {platform: "AQT IBEX (via Braket)", access: "AWS Braket", status: "alternative",
+   cost_per_run: 26.50, annual_52: 26.50 * 52},
 ];
+const sortedCostRows = [...costRows].sort((a, b) => {
+  const order = s => s === "active" ? 0 : 1;
+  const so = order(a.status) - order(b.status);
+  return so !== 0 ? so : a.platform.localeCompare(b.platform);
+});
 ```
 
 ```js
-Inputs.table(costRows.sort((a, b) => a.platform.localeCompare(b.platform)), {
-  select: false,
-  columns: ["platform", "access", "cost_per_run", "annual_52"],
-  header: {platform: "Platform", access: "Access", cost_per_run: "Per run", annual_52: "Annual (52×)"},
-  format: {
-    cost_per_run: d => `$${d.toFixed(2)}`,
-    annual_52: d => `$${d.toFixed(0)}`,
-  },
-})
+html`<table style="width:100%;border-collapse:collapse;font-size:0.875rem;font-family:'Roboto Mono',monospace">
+  <thead>
+    <tr style="border-bottom:2px solid var(--isc-gray-40);text-align:left;font-family:'Work Sans',sans-serif">
+      <th style="padding:0.5rem 1.25rem 0.5rem 0;font-weight:600">Platform</th>
+      <th style="padding:0.5rem 1.25rem;font-weight:600">Access</th>
+      <th style="padding:0.5rem 1.25rem;font-weight:600">Status</th>
+      <th style="padding:0.5rem 1.25rem;text-align:right;font-weight:600">Per run</th>
+      <th style="padding:0.5rem 0 0.5rem 1.25rem;text-align:right;font-weight:600">Annual (52×)</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${sortedCostRows.map(row => {
+      const muted = row.status !== "active";
+      const s = `border-bottom:1px solid var(--isc-gray-20);${muted ? "opacity:0.45" : ""}`;
+      return html`<tr style="${s}">
+        <td style="padding:0.45rem 1.25rem 0.45rem 0">${row.platform}</td>
+        <td style="padding:0.45rem 1.25rem">${row.access}</td>
+        <td style="padding:0.45rem 1.25rem">${row.status === "active" ? "Active" : "Paused"}</td>
+        <td style="padding:0.45rem 1.25rem;text-align:right">$${row.cost_per_run.toFixed(2)}</td>
+        <td style="padding:0.45rem 0 0.45rem 1.25rem;text-align:right">$${row.annual_52.toFixed(0)}</td>
+      </tr>`;
+    })}
+  </tbody>
+</table>`
 ```
 
 *AQT pricing from quotation Q2511001 (Nov 2025), converted at EUR/USD ≈ 1.09. IonQ figure is historical (Aria-1 at $0.03/shot); current Forte would be ~$83/run.*

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -148,30 +148,16 @@ const sortedCostRows = [...costRows].sort((a, b) => {
 ```
 
 ```js
-html`<table style="width:100%;border-collapse:collapse;font-size:0.875rem;font-family:'Roboto Mono',monospace">
-  <thead>
-    <tr style="border-bottom:2px solid var(--isc-gray-40);text-align:left;font-family:'Work Sans',sans-serif">
-      <th style="padding:0.5rem 1.25rem 0.5rem 0;font-weight:600">Platform</th>
-      <th style="padding:0.5rem 1.25rem;font-weight:600">Access</th>
-      <th style="padding:0.5rem 1.25rem;font-weight:600">Status</th>
-      <th style="padding:0.5rem 1.25rem;text-align:right;font-weight:600">Per run</th>
-      <th style="padding:0.5rem 0 0.5rem 1.25rem;text-align:right;font-weight:600">Annual (52×)</th>
-    </tr>
-  </thead>
-  <tbody>
-    ${sortedCostRows.map(row => {
-      const muted = row.status !== "active";
-      const s = `border-bottom:1px solid var(--isc-gray-20);${muted ? "opacity:0.45" : ""}`;
-      return html`<tr style="${s}">
-        <td style="padding:0.45rem 1.25rem 0.45rem 0">${row.platform}</td>
-        <td style="padding:0.45rem 1.25rem">${row.access}</td>
-        <td style="padding:0.45rem 1.25rem">${row.status === "active" ? "Active" : "Paused"}</td>
-        <td style="padding:0.45rem 1.25rem;text-align:right">$${row.cost_per_run.toFixed(2)}</td>
-        <td style="padding:0.45rem 0 0.45rem 1.25rem;text-align:right">$${row.annual_52.toFixed(0)}</td>
-      </tr>`;
-    })}
-  </tbody>
-</table>`
+Inputs.table(sortedCostRows, {
+  select: false,
+  columns: ["platform", "access", "status", "cost_per_run", "annual_52"],
+  header: {platform: "Platform", access: "Access", status: "Status", cost_per_run: "Per run", annual_52: "Annual (52×)"},
+  format: {
+    status: d => html`<span class="badge ${d === "active" ? "badge-active" : "badge-historical"}">${d === "active" ? "Active" : "Paused"}</span>`,
+    cost_per_run: d => `$${d.toFixed(2)}`,
+    annual_52: d => `$${d.toFixed(0)}`,
+  },
+})
 ```
 
 *AQT pricing from quotation Q2511001 (Nov 2025), converted at EUR/USD ≈ 1.09. IonQ figure is historical (Aria-1 at $0.03/shot); current Forte would be ~$83/run.*

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -25,7 +25,7 @@ const sortedSummary = [...summary].sort((a, b) => {
 ${sortedSummary.map(p => html`
   <div class="platform-card">
     <div class="platform-name" style="display:flex;flex-direction:column;align-items:flex-start;gap:0.35rem">
-      ${p.platform === "rigetti_cepheus" ? html`<a href="/rigetti">Rigetti ${p.backend}</a>` :
+      ${p.platform === "rigetti_cepheus" ? html`<a href="/rigetti-cepheus">Rigetti ${p.backend}</a>` :
         p.platform === "rigetti_ankaa"   ? html`<a href="/rigetti-ankaa">Rigetti ${p.backend}</a>` :
         p.platform === "aqt"             ? html`<a href="/aqt">AQT ${p.backend}</a>` :
         p.platform === "ibm"             ? html`<a href="/ibm">IBM ${p.backend}</a>` :

--- a/dashboard/src/rigetti-ankaa.md
+++ b/dashboard/src/rigetti-ankaa.md
@@ -9,7 +9,7 @@ const data = await FileAttachment("data/rigetti-ankaa.json").json();
 
 # Rigetti Ankaa-3
 
-Historical data from Rigetti's 84-qubit Ankaa-3 superconducting QPU, accessed via AWS Braket. Ankaa-3 was retired by Rigetti in April 2026 and succeeded by [Cepheus-1-108Q](/rigetti).
+Historical data from Rigetti's 84-qubit Ankaa-3 superconducting QPU, accessed via AWS Braket. Ankaa-3 was retired by Rigetti in April 2026 and succeeded by [Cepheus-1-108Q](/rigetti-cepheus).
 
 <div style="display: flex; gap: 2rem; margin: 1rem 0;">
   <div class="platform-card" style="flex: 1">

--- a/dashboard/src/rigetti-ankaa.md
+++ b/dashboard/src/rigetti-ankaa.md
@@ -1,20 +1,20 @@
 ---
-title: Rigetti Cepheus-1-108Q
+title: Rigetti Ankaa-3
 ---
 
 ```js
 import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
-const data = await FileAttachment("data/rigetti.json").json();
+const data = await FileAttachment("data/rigetti-ankaa.json").json();
 ```
 
-# Rigetti Cepheus-1-108Q
+# Rigetti Ankaa-3
 
-Rigetti's 108-qubit superconducting QPU, accessed via AWS Braket. Runs weekly on Tuesdays. Succeeded the [Ankaa-3](/rigetti-ankaa) in April 2026.
+Historical data from Rigetti's 84-qubit Ankaa-3 superconducting QPU, accessed via AWS Braket. Ankaa-3 was retired by Rigetti in April 2026 and succeeded by [Cepheus-1-108Q](/rigetti).
 
 <div style="display: flex; gap: 2rem; margin: 1rem 0;">
   <div class="platform-card" style="flex: 1">
     <div class="metric">${(data.runs.at(-1)?.mean_success * 100).toFixed(1)}%</div>
-    <div class="metric-label">Latest run success rate</div>
+    <div class="metric-label">Final run success rate</div>
   </div>
   <div class="platform-card" style="flex: 1">
     <div class="metric">${(data.runs.reduce((s, d) => s + d.mean_success, 0) / data.runs.length * 100).toFixed(1)}%</div>
@@ -35,7 +35,7 @@ Rigetti's 108-qubit superconducting QPU, accessed via AWS Braket. Runs weekly on
 Within-run standard deviation per week — the primary stability metric for this benchmark. Lower is more consistent; an upward trend indicates growing variability.
 
 ```js
-volatilityTimeSeries(data, {color: "#CC8A00"})
+volatilityTimeSeries(data, {color: "#A07800"})
 ```
 
 ## Success probability over time
@@ -43,7 +43,7 @@ volatilityTimeSeries(data, {color: "#CC8A00"})
 Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the 10 circuits sampled that week. The shaded band shows ±1 standard deviation within the run.
 
 ```js
-successTimeSeries(data, {color: "#CC8A00"})
+successTimeSeries(data, {color: "#A07800"})
 ```
 
 ## Performance breakdown
@@ -55,13 +55,13 @@ How success probability varies across circuit depth and input state, aggregated 
 <p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
 
 ```js
-successSurface3D(data, {color: "#CC8A00"})
+successSurface3D(data, {color: "#A07800"})
 ```
 
 ### Distribution by circuit depth
 
 ```js
-boxByLength(data, {color: "#CC8A00"})
+boxByLength(data, {color: "#A07800"})
 ```
 
 ### Mean success by circuit depth
@@ -69,7 +69,7 @@ boxByLength(data, {color: "#CC8A00"})
 Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
 
 ```js
-successByLength(data, {color: "#CC8A00"})
+successByLength(data, {color: "#A07800"})
 ```
 
 ### Mean success by input state
@@ -77,7 +77,7 @@ successByLength(data, {color: "#CC8A00"})
 Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
 
 ```js
-successByInput(data, {color: "#CC8A00"})
+successByInput(data, {color: "#A07800"})
 ```
 
 ## All runs

--- a/dashboard/src/rigetti-cepheus.md
+++ b/dashboard/src/rigetti-cepheus.md
@@ -9,7 +9,7 @@ const data = await FileAttachment("data/rigetti.json").json();
 
 # Rigetti Cepheus-1-108Q
 
-Rigetti's 108-qubit superconducting QPU, accessed via AWS Braket. Runs weekly on Tuesdays. Succeeded the [Ankaa-3](/rigetti-ankaa) in April 2026.
+Rigetti's 108-qubit superconducting QPU, accessed via AWS Braket. Runs weekly on Tuesdays. Succeeded the [Ankaa-3 (historical)](/rigetti-ankaa) in April 2026.
 
 <div style="display: flex; gap: 2rem; margin: 1rem 0;">
   <div class="platform-card" style="flex: 1">


### PR DESCRIPTION
## Summary

**Rigetti platform split:**
- Rigetti Ankaa-3 (historical, retired April 2026) and Cepheus-1-108Q (active) are now separate pages and cards
- New data loader `rigetti-ankaa.json.py` filters to Ankaa rows; `rigetti.json.py` filters to Cepheus rows
- New page `/rigetti-ankaa` with Ankaa-3 historical data; links back to Cepheus successor page
- Ankaa-3 uses a muted gold (`#A07800`); Cepheus keeps the primary gold (`#CC8A00`)

**Nav reorganised:**
- "Active Platforms" section: AQT IBEX, Rigetti Cepheus-1-108Q (alphabetical)
- "Historical" section: IBM Brisbane, IonQ Aria-1, IonQ Forte-1, Rigetti Ankaa-3 (alphabetical)

**Overview cards:**
- Sorted active-first alphabetically, then historical alphabetically
- Status badge now always on its own line (flex-column layout) — fixes the taller-box issue with long platform names

**Cost table:**
- Active rows first alphabetically, historical rows greyed out (`opacity: 0.45`) below
- Added Status column
- Rigetti Ankaa-3 cost restored (`$3.90/run`)
- IBM Brisbane added (was missing)
- Replaced `Inputs.table` with a plain HTML table for per-row styling

## Test plan
- [ ] Overview cards: AQT + Rigetti Cepheus show first; IBM, both IonQs, Rigetti Ankaa show below; all badges on their own line
- [ ] Nav: "Active Platforms" / "Historical" sections visible and correctly populated
- [ ] `/rigetti` shows Cepheus-only data (no Ankaa rows)
- [ ] `/rigetti-ankaa` shows Ankaa-only data with correct charts
- [ ] Cost table: active rows on top, historical rows greyed