### PR TITLE
Add AQT IBEX via AWS Braket (second AQT access path)

### DIFF
--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Collect results
         if: steps.check.outputs.pending_count != '0'
         env:
-          BRAKET_RESULTS_BUCKET: ${{ vars.BRAKET_RESULTS_BUCKET }}
+          BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
+          BRAKET_RESULTS_BUCKET_EAST: ${{ vars.BRAKET_RESULTS_BUCKET_EAST }}
+          BRAKET_RESULTS_BUCKET_EU: ${{ vars.BRAKET_RESULTS_BUCKET_EU }}
+          BRAKET_RESULTS_BUCKET_EU_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_EU_WEST }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
         run: uv run python scripts/collect_results.py
 

--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -68,4 +68,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/ pending/
           git diff --staged --quiet || git commit -m "chore: collect benchmark results $(date -u +%Y-%m-%d)"
-          git push
+          git pull --rebase && git push

--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -57,7 +57,6 @@ jobs:
           BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
           BRAKET_RESULTS_BUCKET_EAST: ${{ vars.BRAKET_RESULTS_BUCKET_EAST }}
           BRAKET_RESULTS_BUCKET_EU: ${{ vars.BRAKET_RESULTS_BUCKET_EU }}
-          BRAKET_RESULTS_BUCKET_EU_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_EU_WEST }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
         run: uv run python scripts/collect_results.py
 

--- a/.github/workflows/submit-benchmark-aqt-braket.yml
+++ b/.github/workflows/submit-benchmark-aqt-braket.yml
@@ -33,7 +33,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: eu-west-2   # AQT Pine is in eu-west-2
+          aws-region: eu-north-1   # AQT IBEX Q1 is in eu-north-1
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -45,7 +45,7 @@ jobs:
 
       - name: Submit jobs
         env:
-          BRAKET_RESULTS_BUCKET_EU_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_EU_WEST }}
+          BRAKET_RESULTS_BUCKET_EU: ${{ vars.BRAKET_RESULTS_BUCKET_EU }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           PLATFORM: aqt_braket
         run: uv run python scripts/submit_benchmark.py

--- a/.github/workflows/submit-benchmark-aqt-braket.yml
+++ b/.github/workflows/submit-benchmark-aqt-braket.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit AQT Braket benchmark $(date -u +%Y-%m-%d)"
-          git push
+          git pull --rebase && git push

--- a/.github/workflows/submit-benchmark-aqt-braket.yml
+++ b/.github/workflows/submit-benchmark-aqt-braket.yml
@@ -1,0 +1,59 @@
+name: Submit AQT Braket Benchmark
+
+on:
+  schedule:
+    # Every Tuesday at 11:00 UTC — 30 min after AQT direct (10:30 UTC) for same-day comparison.
+    - cron: "0 11 * * 2"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: local simulation only (no API calls, no cost)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit AQT Braket circuits
+    runs-on: ubuntu-latest
+    environment: quantum-production
+
+    permissions:
+      contents: write   # to commit pending job files
+      id-token: write   # for OIDC
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-west-2   # AQT Pine is in eu-west-2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Submit jobs
+        env:
+          BRAKET_RESULTS_BUCKET_EU_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_EU_WEST }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          PLATFORM: aqt_braket
+        run: uv run python scripts/submit_benchmark.py
+
+      - name: Commit pending job files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pending/
+          git diff --staged --quiet || git commit -m "chore: submit AQT Braket benchmark $(date -u +%Y-%m-%d)"
+          git push

--- a/.github/workflows/submit-benchmark-ionq-braket.yml
+++ b/.github/workflows/submit-benchmark-ionq-braket.yml
@@ -57,4 +57,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit IonQ Braket benchmark $(date -u +%Y-%m-%d)"
-          git push
+          git pull --rebase && git push

--- a/.github/workflows/submit-benchmark-ionq.yml
+++ b/.github/workflows/submit-benchmark-ionq.yml
@@ -57,4 +57,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit IonQ benchmark $(date -u +%Y-%m-%d)"
-          git push
+          git pull --rebase && git push

--- a/.github/workflows/submit-benchmark-iqm.yml
+++ b/.github/workflows/submit-benchmark-iqm.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit IQM benchmark $(date -u +%Y-%m-%d)"
-          git push
+          git pull --rebase && git push

--- a/.github/workflows/submit-benchmark.yml
+++ b/.github/workflows/submit-benchmark.yml
@@ -70,4 +70,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit benchmark $(date -u +%Y-%m-%d)"
-          git push
+          git pull --rebase && git push

--- a/benchmarks/aqt_braket.py
+++ b/benchmarks/aqt_braket.py
@@ -3,14 +3,11 @@ AQT benchmark via AWS Braket.
 
 Authentication: OIDC-assumed IAM role (set up in infra/). No explicit credentials needed.
 SDK: amazon-braket-sdk
-Backend: AQT Pine (eu-west-2)
-Results bucket: BRAKET_RESULTS_BUCKET_EU_WEST (eu-west-2) — distinct from the IQM/eu-north-1 bucket.
+Backend: AQT IBEX Q1 (eu-north-1)
+Results bucket: BRAKET_RESULTS_BUCKET_EU (eu-north-1) — shared with IQM Garnet.
 
-Uses explicit eu-west-2 boto3 sessions throughout so this module works correctly even when
+Uses explicit eu-north-1 boto3 sessions throughout so this module works correctly even when
 the GitHub Actions workflow configures credentials with a different default region.
-
-TODO: Verify BACKEND_ARN in the AWS Braket console before the first run.
-      AQT devices on Braket: https://us-east-1.console.aws.amazon.com/braket/home#/devices
 """
 
 import importlib.metadata
@@ -21,17 +18,17 @@ from datetime import UTC, date, datetime
 from benchmarks.circuits import REFERENCE_TABLE, build_circuit_braket, sample_circuits
 
 PLATFORM = "aqt_braket"
-BACKEND_ARN = "arn:aws:braket:eu-west-2::device/qpu/aqt/Pine"  # TODO: verify in AWS console
-AWS_REGION = "eu-west-2"
+BACKEND_ARN = "arn:aws:braket:eu-north-1::device/qpu/aqt/Ibex-Q1"
+AWS_REGION = "eu-north-1"
 S3_PREFIX = "condenser-results"
 
 _TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
 
 
 def _s3_folder() -> tuple[str, str]:
-    bucket = os.environ.get("BRAKET_RESULTS_BUCKET_EU_WEST")
+    bucket = os.environ.get("BRAKET_RESULTS_BUCKET_EU")
     if not bucket:
-        raise RuntimeError("BRAKET_RESULTS_BUCKET_EU_WEST environment variable is not set")
+        raise RuntimeError("BRAKET_RESULTS_BUCKET_EU environment variable is not set")
     return (bucket, S3_PREFIX)
 
 

--- a/benchmarks/aqt_braket.py
+++ b/benchmarks/aqt_braket.py
@@ -1,0 +1,180 @@
+"""
+AQT benchmark via AWS Braket.
+
+Authentication: OIDC-assumed IAM role (set up in infra/). No explicit credentials needed.
+SDK: amazon-braket-sdk
+Backend: AQT Pine (eu-west-2)
+Results bucket: BRAKET_RESULTS_BUCKET_EU_WEST (eu-west-2) — distinct from the IQM/eu-north-1 bucket.
+
+Uses explicit eu-west-2 boto3 sessions throughout so this module works correctly even when
+the GitHub Actions workflow configures credentials with a different default region.
+
+TODO: Verify BACKEND_ARN in the AWS Braket console before the first run.
+      AQT devices on Braket: https://us-east-1.console.aws.amazon.com/braket/home#/devices
+"""
+
+import importlib.metadata
+import json
+import os
+from datetime import UTC, date, datetime
+
+from benchmarks.circuits import REFERENCE_TABLE, build_circuit_braket, sample_circuits
+
+PLATFORM = "aqt_braket"
+BACKEND_ARN = "arn:aws:braket:eu-west-2::device/qpu/aqt/Pine"  # TODO: verify in AWS console
+AWS_REGION = "eu-west-2"
+S3_PREFIX = "condenser-results"
+
+_TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+
+def _s3_folder() -> tuple[str, str]:
+    bucket = os.environ.get("BRAKET_RESULTS_BUCKET_EU_WEST")
+    if not bucket:
+        raise RuntimeError("BRAKET_RESULTS_BUCKET_EU_WEST environment variable is not set")
+    return (bucket, S3_PREFIX)
+
+
+def _aws_session():
+    import boto3
+    from braket.aws import AwsSession
+    return AwsSession(boto3.Session(region_name=AWS_REGION))
+
+
+def submit(
+    n_circuits: int = 10, shots: int = 100, dry_run: bool = False, use_simulator: bool = False
+) -> dict:
+    """
+    Submit circuits and return a pending dict.
+    The caller is responsible for saving this to pending/aqt_braket/<date>.json.
+    """
+    if use_simulator:
+        raise RuntimeError(
+            "Cloud simulator not supported for aqt_braket (SV1 is in us-east-1, not eu-west-2). "
+            "Use --dry-run for local simulation."
+        )
+
+    from braket.aws import AwsDevice
+    from braket.devices import LocalSimulator
+
+    sdk_version = importlib.metadata.version("amazon-braket-sdk")
+
+    if dry_run:
+        device = LocalSimulator()
+        backend = "LocalSimulator"
+        s3_folder = ("dry-run-bucket", S3_PREFIX)
+    else:
+        device = AwsDevice(BACKEND_ARN, aws_session=_aws_session())
+        backend = device.name
+        s3_folder = _s3_folder()
+
+    sampled_keys = sample_circuits(n_circuits)
+    circuits = [build_circuit_braket(input_bits, length) for input_bits, length in sampled_keys]
+
+    print(f"  Submitting {len(circuits)} circuits to {backend}...")
+    if dry_run:
+        tasks = [device.run(circuit, shots=shots) for circuit in circuits]
+    else:
+        tasks = [device.run(circuit, s3_folder, shots=shots) for circuit in circuits]
+
+    pending = {
+        "run_date": date.today().isoformat(),
+        "platform": PLATFORM,
+        "backend": backend,
+        "sdk_version": sdk_version,
+        "shots": shots,
+        "submitted_at": datetime.now(UTC).isoformat(),
+        "dry_run": dry_run,
+        "jobs": [
+            {"job_id": task.id, "input_bits": input_bits, "circuit_length": circuit_length}
+            for task, (input_bits, circuit_length) in zip(tasks, sampled_keys)
+        ],
+    }
+
+    if dry_run:
+        pending["_dry_run_results"] = _collect_tasks(pending["jobs"], tasks, pending)
+
+    return pending
+
+
+def _collect_tasks(jobs_meta: list, tasks: list, pending: dict) -> list[dict]:
+    """Build result dicts from already-completed task objects (used for dry runs)."""
+    results = []
+    for job_meta, task in zip(jobs_meta, tasks):
+        result = task.result()
+        counts = dict(result.measurement_counts)
+        correct = REFERENCE_TABLE[(job_meta["input_bits"], job_meta["circuit_length"])]
+        success_prob = counts.get(correct, 0) / pending["shots"]
+        metadata = result.task_metadata
+        results.append({
+            "run_date": pending["run_date"],
+            "platform": pending["platform"],
+            "backend": pending["backend"],
+            "input_bits": job_meta["input_bits"],
+            "circuit_length": job_meta["circuit_length"],
+            "shots": pending["shots"],
+            "counts_json": json.dumps(counts),
+            "success_probability": round(success_prob, 4),
+            "job_id": job_meta["job_id"],
+            "job_start_time": getattr(metadata, "createdAt", None),
+            "job_end_time": getattr(metadata, "endedAt", None),
+            "sdk_version": pending["sdk_version"],
+            "notes": "dry_run",
+        })
+    return results
+
+
+def collect(pending: dict) -> list[dict] | None:
+    """
+    Check the status of pending jobs.
+
+    Returns a list of result dicts if all jobs are done.
+    Returns None if any jobs are still queued or running.
+    Raises RuntimeError if any jobs failed or were cancelled.
+    """
+    if "_dry_run_results" in pending:
+        return pending["_dry_run_results"]
+
+    from braket.aws import AwsQuantumTask
+
+    aws_session = _aws_session()
+    jobs = pending["jobs"]
+    tasks = [AwsQuantumTask(job["job_id"], aws_session=aws_session) for job in jobs]
+    states = [task.state() for task in tasks]
+
+    failed = [job["job_id"] for job, state in zip(jobs, states) if state in ("FAILED", "CANCELLED")]
+    if failed:
+        raise RuntimeError(f"Jobs failed/cancelled: {failed}")
+
+    still_pending = [
+        job["job_id"] for job, state in zip(jobs, states) if state not in _TERMINAL_STATES
+    ]
+    if still_pending:
+        print(f"  {len(still_pending)}/{len(jobs)} jobs still pending.")
+        return None
+
+    print(f"  All {len(jobs)} jobs complete. Collecting results...")
+    results = []
+    for job_meta, task in zip(jobs, tasks):
+        result = task.result()
+        counts = dict(result.measurement_counts)
+        correct = REFERENCE_TABLE[(job_meta["input_bits"], job_meta["circuit_length"])]
+        success_prob = counts.get(correct, 0) / pending["shots"]
+
+        metadata = result.task_metadata
+        results.append({
+            "run_date": pending["run_date"],
+            "platform": pending["platform"],
+            "backend": pending["backend"],
+            "input_bits": job_meta["input_bits"],
+            "circuit_length": job_meta["circuit_length"],
+            "shots": pending["shots"],
+            "counts_json": json.dumps(counts),
+            "success_probability": round(success_prob, 4),
+            "job_id": job_meta["job_id"],
+            "job_start_time": getattr(metadata, "createdAt", None),
+            "job_end_time": getattr(metadata, "endedAt", None),
+            "sdk_version": pending["sdk_version"],
+            "notes": "",
+        })
+    return results

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -7,6 +7,7 @@ export default {
       name: "Active Platforms",
       pages: [
         {name: "AQT IBEX", path: "/aqt"},
+        {name: "AQT IBEX (Braket)", path: "/aqt-braket"},
         {name: "IonQ Forte-1 (Braket)", path: "/ionq-forte-braket"},
         {name: "Rigetti Cepheus-1-108Q", path: "/rigetti-cepheus"},
       ]

--- a/dashboard/src/aqt-braket.md
+++ b/dashboard/src/aqt-braket.md
@@ -9,7 +9,7 @@ const data = await FileAttachment("data/aqt-braket.json").json();
 
 # AQT IBEX (Braket)
 
-AQT trapped-ion QPU accessed via AWS Braket (eu-west-2). Weekly runs on Tuesdays, offset from the [direct API path](/aqt) by 30 minutes. At ~$26.50/run this offers a cost comparison point against AQT direct (~$25.07/run).
+AQT trapped-ion QPU accessed via AWS Braket (eu-north-1). Weekly runs on Tuesdays, offset from the [direct API path](/aqt) by 30 minutes. At ~$26.50/run this offers a cost comparison point against AQT direct (~$25.07/run).
 
 <div style="display: flex; gap: 2rem; margin: 1rem 0;">
   <div class="platform-card" style="flex: 1">

--- a/dashboard/src/aqt-braket.md
+++ b/dashboard/src/aqt-braket.md
@@ -1,0 +1,119 @@
+---
+title: AQT IBEX (Braket)
+---
+
+```js
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
+const data = await FileAttachment("data/aqt-braket.json").json();
+```
+
+# AQT IBEX (Braket)
+
+AQT trapped-ion QPU accessed via AWS Braket (eu-west-2). Weekly runs on Tuesdays, offset from the [direct API path](/aqt) by 30 minutes. At ~$26.50/run this offers a cost comparison point against AQT direct (~$25.07/run).
+
+<div style="display: flex; gap: 2rem; margin: 1rem 0;">
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length > 0 ? (data.runs.at(-1)?.mean_success * 100).toFixed(1) + "%" : "—"}</div>
+    <div class="metric-label">Latest run success rate</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length > 0 ? (data.runs.reduce((s, d) => s + d.mean_success, 0) / data.runs.length * 100).toFixed(1) + "%" : "—"}</div>
+    <div class="metric-label">All-time mean</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length}</div>
+    <div class="metric-label">Runs</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.circuits.length}</div>
+    <div class="metric-label">Total circuits</div>
+  </div>
+</div>
+
+${data.runs.length === 0 ? html`<div style="color: var(--isc-muted); font-style: italic; margin: 2rem 0;">No data yet — first automated run scheduled for the next Tuesday.</div>` : ""}
+
+## Consistency over time
+
+Within-run consistency score (1 - std dev) — the primary stability metric. Higher is more consistent. Faded line and dots are individual runs; bold line and larger dots are the 4-run rolling average.
+
+```js
+volatilityTimeSeries(data, {color: "#5B7FA3"})
+```
+
+## Success probability over time
+
+Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the circuits sampled that run. The bold line is the 4-run rolling average; faded line and dots are individual runs. The shaded band shows ±1 standard deviation within the run.
+
+```js
+successTimeSeries(data, {color: "#5B7FA3"})
+```
+
+## Performance breakdown
+
+How success probability varies across circuit depth and input state, aggregated across all runs.
+
+### Success probability by circuit depth and input state
+
+<p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
+
+```js
+successSurface3D(data, {color: "#5B7FA3"})
+```
+
+### Distribution by circuit depth
+
+```js
+boxByLength(data, {color: "#5B7FA3"})
+```
+
+### Mean success by circuit depth
+
+Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
+
+```js
+successByLength(data, {color: "#5B7FA3"})
+```
+
+### Mean success by input state
+
+Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
+
+```js
+successByInput(data, {color: "#5B7FA3"})
+```
+
+## Incidents
+
+```js
+data.incidents?.length > 0 ? Inputs.table([...data.incidents].reverse(), {
+  select: false,
+  columns: ["incident_date", "type", "notes", "error_message"],
+  header: {incident_date: "Date", type: "Type", notes: "Notes", error_message: "Error"},
+  width: {incident_date: 110, type: 160, notes: 220, error_message: 300},
+  format: {
+    type: d => {
+      const colors = {platform_offline: "#E53E3E", automation_error: "#DD6B20", planned_transition: "#718096", queue_timeout: "#805AD5"};
+      return html`<span style="color:${colors[d] ?? "#718096"};font-weight:600">${d.replace(/_/g, " ")}</span>`;
+    },
+  },
+}) : html`<p style="color: var(--isc-muted); font-style: italic">No incidents recorded.</p>`
+```
+
+## All runs
+
+```js
+Inputs.table(data.runs.slice().reverse(), {
+  select: false,
+  columns: ["run_date", "mean_success", "std_success", "n_circuits"],
+  header: {
+    run_date: "Date",
+    mean_success: "Mean success",
+    std_success: "Std dev",
+    n_circuits: "Circuits",
+  },
+  format: {
+    mean_success: d => `${(d * 100).toFixed(1)}%`,
+    std_success: d => `±${(d * 100).toFixed(1)}%`,
+  },
+})
+```

--- a/dashboard/src/data/aqt-braket.json.py
+++ b/dashboard/src/data/aqt-braket.json.py
@@ -1,0 +1,65 @@
+"""
+Data loader: AQT Pine (via AWS Braket) results.
+Reads data/aqt_braket/results.csv (separate from the direct qiskit-aqt-provider CSV).
+"""
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+repo_root = Path(__file__).parents[3]
+csv_path = repo_root / "data" / "aqt_braket" / "results.csv"
+
+if not csv_path.exists():
+    json.dump({"runs": [], "circuits": [], "by_length": [], "by_input": [], "incidents": []}, sys.stdout)
+    sys.exit(0)
+
+df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
+df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
+
+if df.empty:
+    json.dump({"runs": [], "circuits": [], "by_length": [], "by_input": [], "incidents": []}, sys.stdout)
+    sys.exit(0)
+
+runs = (
+    df.groupby("run_date")["success_probability"]
+    .agg(mean_success="mean", std_success="std", n_circuits="count")
+    .reset_index()
+    .sort_values("run_date")
+)
+runs["run_date"] = runs["run_date"].dt.strftime("%Y-%m-%d")
+runs["mean_success"] = runs["mean_success"].round(4)
+runs["std_success"] = runs["std_success"].fillna(0).round(4)
+
+circuits = df[["run_date", "input_bits", "circuit_length", "success_probability", "job_end_time"]].copy()
+circuits["run_date"] = circuits["run_date"].dt.strftime("%Y-%m-%d")
+circuits = circuits.astype(object).where(pd.notnull(circuits), None)
+
+by_length = (
+    df.groupby("circuit_length")["success_probability"]
+    .agg(mean_success="mean", std_success="std", n="count", median="median")
+    .reset_index()
+    .rename(columns={"circuit_length": "length"})
+).round(4)
+
+by_input = (
+    df.groupby("input_bits")["success_probability"]
+    .agg(mean_success="mean", std_success="std", n="count")
+    .reset_index()
+).round(4)
+
+inc_path = repo_root / "incidents" / "aqt_braket" / "incidents.csv"
+incidents = pd.read_csv(inc_path, dtype=str).fillna("").to_dict(orient="records") if inc_path.exists() else []
+
+output = {
+    "platform": "aqt_braket",
+    "backend": "AQT Pine (Braket)",
+    "runs": runs.to_dict(orient="records"),
+    "circuits": circuits.to_dict(orient="records"),
+    "by_length": by_length.to_dict(orient="records"),
+    "by_input": by_input.to_dict(orient="records"),
+    "incidents": incidents,
+}
+
+json.dump(output, sys.stdout)

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -22,6 +22,8 @@ PLATFORMS = {
                         "csv_key": "rigetti", "backend_filter": "Ankaa"},
     "rigetti_cepheus": {"backend": "Cepheus-1-108Q", "status": "active",    "cost_per_run_usd": 3.43,
                         "csv_key": "rigetti", "backend_filter": "Cepheus"},
+    "aqt_braket":      {"backend": "IBEX (Braket)", "status": "active",     "cost_per_run_usd": 26.50,
+                        "csv_key": "aqt_braket"},
 }
 
 summary = []

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -37,6 +37,7 @@ ${sortedSummary.map(p => html`
       ${p.platform === "rigetti_cepheus" ? html`<a href="/rigetti-cepheus">Rigetti ${p.backend}</a>` :
         p.platform === "rigetti_ankaa"   ? html`<a href="/rigetti-ankaa">Rigetti ${p.backend}</a>` :
         p.platform === "aqt"             ? html`<a href="/aqt">AQT ${p.backend}</a>` :
+        p.platform === "aqt_braket"      ? html`<a href="/aqt-braket">AQT ${p.backend}</a>` :
         p.platform === "ibm"             ? html`<a href="/ibm">IBM ${p.backend}</a>` :
         p.platform === "ionq_forte_direct"  ? html`<a href="/ionq-forte-direct">IonQ ${p.backend}</a>` :
         p.platform === "ionq_forte_braket"  ? html`<a href="/ionq-forte-braket">IonQ ${p.backend}</a>` :
@@ -60,12 +61,12 @@ Within-run consistency score (1 - std dev) per run — higher is more consistent
 
 ```js
 const PLATFORM_LABEL = {
-  aqt: "AQT IBEX", ibm: "IBM Brisbane",
+  aqt: "AQT IBEX", aqt_braket: "AQT IBEX (Braket)", ibm: "IBM Brisbane",
   ionq: "IonQ Aria-1", ionq_forte_direct: "IonQ Forte-1 (direct)", ionq_forte_braket: "IonQ Forte-1 (Braket)",
   rigetti_ankaa: "Rigetti Ankaa-3", rigetti_cepheus: "Rigetti Cepheus-1-108Q",
 };
 const PLATFORM_COLOR = {
-  aqt: "#363D47", ibm: "#1192E8",
+  aqt: "#363D47", aqt_braket: "#5B7FA3", ibm: "#1192E8",
   ionq: "#74737B", ionq_forte_direct: "#99979D", ionq_forte_braket: "#6B8CAE",
   rigetti_ankaa: "#A07800", rigetti_cepheus: "#CC8A00",
 };
@@ -163,18 +164,18 @@ Plot.plot({
 
 ```js
 const PLATFORM_NAME = {
-  aqt: "AQT IBEX (direct)", ibm: "IBM Brisbane",
+  aqt: "AQT IBEX (direct)", aqt_braket: "AQT IBEX (Braket)", ibm: "IBM Brisbane",
   ionq: "IonQ Aria-1", ionq_forte_direct: "IonQ Forte-1 (direct)", ionq_forte_braket: "IonQ Forte-1 (Braket)",
   rigetti_ankaa: "Rigetti Ankaa-3", rigetti_cepheus: "Rigetti Cepheus-1-108Q",
 };
 const ACCESS = {
-  aqt: "qiskit-aqt-provider", ibm: "Qiskit Runtime (historical)",
+  aqt: "qiskit-aqt-provider", aqt_braket: "AWS Braket", ibm: "Qiskit Runtime (historical)",
   ionq: "AWS Braket (historical)", ionq_forte_direct: "IonQ REST API (historical)",
   ionq_forte_braket: "AWS Braket",
   rigetti_ankaa: "AWS Braket (historical)", rigetti_cepheus: "AWS Braket",
 };
 const SCHEDULE = {
-  aqt: "Weekly", ibm: "—",
+  aqt: "Weekly", aqt_braket: "Weekly", ibm: "—",
   ionq: "Weekly", ionq_forte_direct: "Monthly", ionq_forte_braket: "Monthly",
   rigetti_ankaa: "Weekly", rigetti_cepheus: "Weekly",
 };
@@ -196,8 +197,6 @@ const costRows = [
       annual_actual: actualAnnual(p.cost_per_run_usd, schedule),
     };
   }),
-  {platform: "AQT IBEX (via Braket)", access: "AWS Braket", schedule: "Weekly",
-   status: "alternative", cost_per_run: 26.50, annual_52: 26.50 * 52, annual_actual: 26.50 * 52},
 ];
 const sortedCostRows = [...costRows].sort((a, b) => {
   const order = s => s === "active" ? 0 : 1;

--- a/data/aqt_braket/results.csv
+++ b/data/aqt_braket/results.csv
@@ -1,0 +1,1 @@
+run_date,platform,backend,input_bits,circuit_length,shots,counts_json,success_probability,job_id,job_start_time,job_end_time,sdk_version,notes

--- a/incidents/aqt_braket/incidents.csv
+++ b/incidents/aqt_braket/incidents.csv
@@ -1,0 +1,1 @@
+incident_date,platform,type,error_message,notes

--- a/infra/iam-policy.json
+++ b/infra/iam-policy.json
@@ -28,9 +28,7 @@
         "arn:aws:s3:::amazon-braket-isc-condenser-east",
         "arn:aws:s3:::amazon-braket-isc-condenser-east/*",
         "arn:aws:s3:::amazon-braket-isc-condenser-eu",
-        "arn:aws:s3:::amazon-braket-isc-condenser-eu/*",
-        "arn:aws:s3:::amazon-braket-isc-condenser-eu-west",
-        "arn:aws:s3:::amazon-braket-isc-condenser-eu-west/*"
+        "arn:aws:s3:::amazon-braket-isc-condenser-eu/*"
       ]
     }
   ]

--- a/infra/iam-policy.json
+++ b/infra/iam-policy.json
@@ -28,7 +28,9 @@
         "arn:aws:s3:::amazon-braket-isc-condenser-east",
         "arn:aws:s3:::amazon-braket-isc-condenser-east/*",
         "arn:aws:s3:::amazon-braket-isc-condenser-eu",
-        "arn:aws:s3:::amazon-braket-isc-condenser-eu/*"
+        "arn:aws:s3:::amazon-braket-isc-condenser-eu/*",
+        "arn:aws:s3:::amazon-braket-isc-condenser-eu-west",
+        "arn:aws:s3:::amazon-braket-isc-condenser-eu-west/*"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Adds `aqt_braket` as a second AQT platform path via AWS Braket (eu-west-2), mirroring the IonQ direct/Braket split
- New benchmark module (`benchmarks/aqt_braket.py`) uses AQT Pine ARN, explicit eu-west-2 boto3 session, `BRAKET_RESULTS_BUCKET_EU_WEST` env var
- Weekly automation workflow (`submit-benchmark-aqt-braket.yml`) runs Tuesdays 11:00 UTC, 30 min after AQT direct
- Full dashboard page (`/aqt-braket`) with all charts; graceful "No data yet" until first run
- Wired into overview page (consistency chart, success chart, cost table, platform cards, nav)
- `collect-results.yml` now passes all 4 region-specific bucket vars instead of generic `BRAKET_RESULTS_BUCKET`
- `infra/iam-policy.json` updated with `amazon-braket-isc-condenser-eu-west` bucket ARNs

## Before merging

- [ ] Create S3 bucket `amazon-braket-isc-condenser-eu-west` in eu-west-2
- [ ] Add `BRAKET_RESULTS_BUCKET_EU_WEST` variable to the `quantum-production` GitHub environment
- [ ] Verify AQT Pine device ARN (`arn:aws:braket:eu-west-2::device/qpu/aqt/Pine`) in AWS Braket console
- [ ] Apply updated IAM inline policy: `aws iam put-role-policy --role-name condenser-github-actions --policy-name condenser-braket-policy --policy-document file://infra/iam-policy.json`

## Test plan

- [ ] Dry-run smoke test: `PLATFORM=aqt_braket DRY_RUN=true uv run python scripts/submit_benchmark.py`
- [ ] Dashboard builds without errors after merge