### PR TITLE
Add IQM Garnet to dashboard

### DIFF
--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -8,6 +8,7 @@ export default {
       pages: [
         {name: "AQT IBEX", path: "/aqt"},
         {name: "AQT IBEX (Braket)", path: "/aqt-braket"},
+        {name: "IQM Garnet", path: "/iqm"},
         {name: "IonQ Forte-1 (Braket)", path: "/ionq-forte-braket"},
         {name: "Rigetti Cepheus-1-108Q", path: "/rigetti-cepheus"},
       ]

--- a/dashboard/src/data/iqm.json.py
+++ b/dashboard/src/data/iqm.json.py
@@ -1,0 +1,64 @@
+"""
+Data loader: IQM Garnet (via AWS Braket) results.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+repo_root = Path(__file__).parents[3]
+csv_path = repo_root / "data" / "iqm_braket" / "results.csv"
+
+if not csv_path.exists():
+    json.dump({"runs": [], "circuits": [], "by_length": [], "by_input": [], "incidents": []}, sys.stdout)
+    sys.exit(0)
+
+df = pd.read_csv(csv_path, parse_dates=["run_date"], dtype={"input_bits": str})
+df = df[~df["notes"].fillna("").str.contains("dry_run|simulator")]
+
+if df.empty:
+    json.dump({"runs": [], "circuits": [], "by_length": [], "by_input": [], "incidents": []}, sys.stdout)
+    sys.exit(0)
+
+runs = (
+    df.groupby("run_date")["success_probability"]
+    .agg(mean_success="mean", std_success="std", n_circuits="count")
+    .reset_index()
+    .sort_values("run_date")
+)
+runs["run_date"] = runs["run_date"].dt.strftime("%Y-%m-%d")
+runs["mean_success"] = runs["mean_success"].round(4)
+runs["std_success"] = runs["std_success"].fillna(0).round(4)
+
+circuits = df[["run_date", "input_bits", "circuit_length", "success_probability", "job_end_time"]].copy()
+circuits["run_date"] = circuits["run_date"].dt.strftime("%Y-%m-%d")
+circuits = circuits.astype(object).where(pd.notnull(circuits), None)
+
+by_length = (
+    df.groupby("circuit_length")["success_probability"]
+    .agg(mean_success="mean", std_success="std", n="count", median="median")
+    .reset_index()
+    .rename(columns={"circuit_length": "length"})
+).round(4)
+
+by_input = (
+    df.groupby("input_bits")["success_probability"]
+    .agg(mean_success="mean", std_success="std", n="count")
+    .reset_index()
+).round(4)
+
+inc_path = repo_root / "incidents" / "iqm_braket" / "incidents.csv"
+incidents = pd.read_csv(inc_path, dtype=str).fillna("").to_dict(orient="records") if inc_path.exists() else []
+
+output = {
+    "platform": "iqm_braket",
+    "backend": "IQM Garnet",
+    "runs": runs.to_dict(orient="records"),
+    "circuits": circuits.to_dict(orient="records"),
+    "by_length": by_length.to_dict(orient="records"),
+    "by_input": by_input.to_dict(orient="records"),
+    "incidents": incidents,
+}
+
+json.dump(output, sys.stdout)

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -24,6 +24,8 @@ PLATFORMS = {
                         "csv_key": "rigetti", "backend_filter": "Cepheus"},
     "aqt_braket":      {"backend": "IBEX (Braket)", "status": "active",     "cost_per_run_usd": 26.50,
                         "csv_key": "aqt_braket"},
+    "iqm_braket":      {"backend": "Garnet",        "status": "active",     "cost_per_run_usd": 4.45,
+                        "csv_key": "iqm_braket"},
 }
 
 summary = []

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -38,6 +38,7 @@ ${sortedSummary.map(p => html`
         p.platform === "rigetti_ankaa"   ? html`<a href="/rigetti-ankaa">Rigetti ${p.backend}</a>` :
         p.platform === "aqt"             ? html`<a href="/aqt">AQT ${p.backend}</a>` :
         p.platform === "aqt_braket"      ? html`<a href="/aqt-braket">AQT ${p.backend}</a>` :
+        p.platform === "iqm_braket"      ? html`<a href="/iqm">IQM ${p.backend}</a>` :
         p.platform === "ibm"             ? html`<a href="/ibm">IBM ${p.backend}</a>` :
         p.platform === "ionq_forte_direct"  ? html`<a href="/ionq-forte-direct">IonQ ${p.backend}</a>` :
         p.platform === "ionq_forte_braket"  ? html`<a href="/ionq-forte-braket">IonQ ${p.backend}</a>` :
@@ -63,11 +64,13 @@ Within-run consistency score (1 - std dev) per run — higher is more consistent
 const PLATFORM_LABEL = {
   aqt: "AQT IBEX", aqt_braket: "AQT IBEX (Braket)", ibm: "IBM Brisbane",
   ionq: "IonQ Aria-1", ionq_forte_direct: "IonQ Forte-1 (direct)", ionq_forte_braket: "IonQ Forte-1 (Braket)",
+  iqm_braket: "IQM Garnet",
   rigetti_ankaa: "Rigetti Ankaa-3", rigetti_cepheus: "Rigetti Cepheus-1-108Q",
 };
 const PLATFORM_COLOR = {
   aqt: "#363D47", aqt_braket: "#5B7FA3", ibm: "#1192E8",
   ionq: "#74737B", ionq_forte_direct: "#99979D", ionq_forte_braket: "#6B8CAE",
+  iqm_braket: "#2E8B74",
   rigetti_ankaa: "#A07800", rigetti_cepheus: "#CC8A00",
 };
 const allRuns = summary.flatMap(p =>
@@ -166,17 +169,19 @@ Plot.plot({
 const PLATFORM_NAME = {
   aqt: "AQT IBEX (direct)", aqt_braket: "AQT IBEX (Braket)", ibm: "IBM Brisbane",
   ionq: "IonQ Aria-1", ionq_forte_direct: "IonQ Forte-1 (direct)", ionq_forte_braket: "IonQ Forte-1 (Braket)",
+  iqm_braket: "IQM Garnet",
   rigetti_ankaa: "Rigetti Ankaa-3", rigetti_cepheus: "Rigetti Cepheus-1-108Q",
 };
 const ACCESS = {
   aqt: "qiskit-aqt-provider", aqt_braket: "AWS Braket", ibm: "Qiskit Runtime (historical)",
   ionq: "AWS Braket (historical)", ionq_forte_direct: "IonQ REST API (historical)",
-  ionq_forte_braket: "AWS Braket",
+  ionq_forte_braket: "AWS Braket", iqm_braket: "AWS Braket",
   rigetti_ankaa: "AWS Braket (historical)", rigetti_cepheus: "AWS Braket",
 };
 const SCHEDULE = {
   aqt: "Weekly", aqt_braket: "Weekly", ibm: "—",
   ionq: "Weekly", ionq_forte_direct: "Monthly", ionq_forte_braket: "Monthly",
+  iqm_braket: "Weekly",
   rigetti_ankaa: "Weekly", rigetti_cepheus: "Weekly",
 };
 function actualAnnual(cost, schedule) {

--- a/dashboard/src/iqm.md
+++ b/dashboard/src/iqm.md
@@ -1,0 +1,119 @@
+---
+title: IQM Garnet
+---
+
+```js
+import {successTimeSeries, volatilityTimeSeries, boxByLength, successByLength, successByInput, successSurface3D} from "./components/platformCharts.js";
+const data = await FileAttachment("data/iqm.json").json();
+```
+
+# IQM Garnet
+
+IQM superconducting QPU accessed via AWS Braket (eu-north-1). Weekly runs on Wednesdays at 10:30 UTC.
+
+<div style="display: flex; gap: 2rem; margin: 1rem 0;">
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length > 0 ? (data.runs.at(-1)?.mean_success * 100).toFixed(1) + "%" : "—"}</div>
+    <div class="metric-label">Latest run success rate</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length > 0 ? (data.runs.reduce((s, d) => s + d.mean_success, 0) / data.runs.length * 100).toFixed(1) + "%" : "—"}</div>
+    <div class="metric-label">All-time mean</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.runs.length}</div>
+    <div class="metric-label">Runs</div>
+  </div>
+  <div class="platform-card" style="flex: 1">
+    <div class="metric">${data.circuits.length}</div>
+    <div class="metric-label">Total circuits</div>
+  </div>
+</div>
+
+${data.runs.length === 0 ? html`<div style="color: var(--isc-muted); font-style: italic; margin: 2rem 0;">No data yet — first automated run scheduled for the next Wednesday.</div>` : ""}
+
+## Consistency over time
+
+Within-run consistency score (1 - std dev) — the primary stability metric. Higher is more consistent. Faded line and dots are individual runs; bold line and larger dots are the 4-run rolling average.
+
+```js
+volatilityTimeSeries(data, {color: "#2E8B74"})
+```
+
+## Success probability over time
+
+Success probability for a given circuit is the fraction of shots that produced the correct output — where "correct" is the deterministic, noise-free answer computed by classical simulation. Each point is the mean across the circuits sampled that run. The bold line is the 4-run rolling average; faded line and dots are individual runs. The shaded band shows ±1 standard deviation within the run.
+
+```js
+successTimeSeries(data, {color: "#2E8B74"})
+```
+
+## Performance breakdown
+
+How success probability varies across circuit depth and input state, aggregated across all runs.
+
+### Success probability by circuit depth and input state
+
+<p style="margin-bottom:0">Each point is one (depth, input state) combination. Point size reflects how many circuits were run with that combination. Drag to rotate.</p>
+
+```js
+successSurface3D(data, {color: "#2E8B74"})
+```
+
+### Distribution by circuit depth
+
+```js
+boxByLength(data, {color: "#2E8B74"})
+```
+
+### Mean success by circuit depth
+
+Mean success probability for each depth, averaged across all runs. A declining trend confirms that noise accumulates as circuit depth increases.
+
+```js
+successByLength(data, {color: "#2E8B74"})
+```
+
+### Mean success by input state
+
+Does the initial qubit state affect results? Ideally it shouldn't — deviations suggest state-preparation or readout asymmetry.
+
+```js
+successByInput(data, {color: "#2E8B74"})
+```
+
+## Incidents
+
+```js
+data.incidents?.length > 0 ? Inputs.table([...data.incidents].reverse(), {
+  select: false,
+  columns: ["incident_date", "type", "notes", "error_message"],
+  header: {incident_date: "Date", type: "Type", notes: "Notes", error_message: "Error"},
+  width: {incident_date: 110, type: 160, notes: 220, error_message: 300},
+  format: {
+    type: d => {
+      const colors = {platform_offline: "#E53E3E", automation_error: "#DD6B20", planned_transition: "#718096", queue_timeout: "#805AD5"};
+      return html`<span style="color:${colors[d] ?? "#718096"};font-weight:600">${d.replace(/_/g, " ")}</span>`;
+    },
+  },
+}) : html`<p style="color: var(--isc-muted); font-style: italic">No incidents recorded.</p>`
+```
+
+## All runs
+
+```js
+Inputs.table(data.runs.slice().reverse(), {
+  select: false,
+  columns: ["run_date", "mean_success", "std_success", "n_circuits"],
+  header: {
+    run_date: "Date",
+    mean_success: "Mean success",
+    std_success: "Std dev",
+    n_circuits: "Circuits",
+  },
+  format: {
+    mean_success: d => `${(d * 100).toFixed(1)}%`,
+    std_success: d => `±${(d * 100).toFixed(1)}%`,
+  },
+})
+```

--- a/incidents/iqm_braket/incidents.csv
+++ b/incidents/iqm_braket/incidents.csv
@@ -1,0 +1,1 @@
+incident_date,platform,type,error_message,notes


### PR DESCRIPTION
## Summary

- New platform page at `/iqm` with all standard charts (consistency, success, breakdown, incidents, all-runs table)
- Data loader reading `data/iqm_braket/results.csv` — 3 runs already collected (Apr 22, Apr 29, May 6)
- Wired into overview: platform card, consistency chart, success chart, cost table ($4.45/run, Weekly)
- Added to nav under Active Platforms
- Empty `incidents/iqm_braket/incidents.csv` seed file

## Test plan

- [ ] Dashboard builds without errors
- [ ] IQM Garnet card appears on overview with 3 runs of data
- [ ] `/iqm` page renders all charts correctly