### PR TITLE
Enable IBM Brisbane benchmarks

### DIFF
--- a/.github/workflows/submit-benchmark.yml
+++ b/.github/workflows/submit-benchmark.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           BRAKET_RESULTS_BUCKET_WEST: ${{ vars.BRAKET_RESULTS_BUCKET_WEST }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
+          IBM_QUANTUM_TOKEN: ${{ secrets.IBM_QUANTUM_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           USE_SIMULATOR: ${{ inputs.simulator || 'false' }}
           PLATFORM: ${{ inputs.platform || '' }}

--- a/dashboard/src/data/summary.json.py
+++ b/dashboard/src/data/summary.json.py
@@ -11,7 +11,7 @@ repo_root = Path(__file__).parents[3]
 
 PLATFORMS = {
     "aqt":        {"backend": "IBEX",     "status": "active",     "cost_per_run_usd": 25.07},
-    "ibm":        {"backend": "Brisbane", "status": "historical", "cost_per_run_usd": None},
+    "ibm":        {"backend": "Brisbane", "status": "active",     "cost_per_run_usd": None},
     "ionq":       {"backend": "Aria-1",  "status": "historical", "cost_per_run_usd": 33.00,
                    "csv_key": "ionq", "backend_filter": "Aria"},
     "ionq_forte_direct": {"backend": "Forte-1 (direct)", "status": "historical", "cost_per_run_usd": 259.00,

--- a/scripts/submit_benchmark.py
+++ b/scripts/submit_benchmark.py
@@ -24,8 +24,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 ENABLED_PLATFORMS = [
     "rigetti_braket",  # active: Rigetti Ankaa-3 via AWS Braket (us-west-1)
     "aqt_qiskit",      # active: AQT via qiskit-aqt-provider; requires AQT_API_KEY secret
+    "ibm_qiskit",      # active: IBM Brisbane via Qiskit Runtime; requires IBM_QUANTUM_TOKEN secret
     # "ionq_braket",   # paused: budget
-    # "ibm_qiskit",    # pending: locate Sami's notebook and existing results
 ]
 
 


### PR DESCRIPTION
## Summary

- Adds `IBM_QUANTUM_TOKEN` to the submit workflow env
- Enables `ibm_qiskit` in `ENABLED_PLATFORMS`
- Flips IBM status to active in summary.json.py

## Test plan

- [ ] Merge, then trigger a manual workflow_dispatch on Submit Benchmark with platform=ibm_qiskit