### PR TITLE
Fix git pull --rebase failing due to unstaged uv.lock changes

### DIFF
--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -67,4 +67,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/ pending/
           git diff --staged --quiet || git commit -m "chore: collect benchmark results $(date -u +%Y-%m-%d)"
-          git pull --rebase && git push
+          git pull --rebase --autostash && git push

--- a/.github/workflows/submit-benchmark-aqt-braket.yml
+++ b/.github/workflows/submit-benchmark-aqt-braket.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit AQT Braket benchmark $(date -u +%Y-%m-%d)"
-          git pull --rebase && git push
+          git pull --rebase --autostash && git push

--- a/.github/workflows/submit-benchmark-ionq-braket.yml
+++ b/.github/workflows/submit-benchmark-ionq-braket.yml
@@ -57,4 +57,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit IonQ Braket benchmark $(date -u +%Y-%m-%d)"
-          git pull --rebase && git push
+          git pull --rebase --autostash && git push

--- a/.github/workflows/submit-benchmark-ionq.yml
+++ b/.github/workflows/submit-benchmark-ionq.yml
@@ -57,4 +57,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit IonQ benchmark $(date -u +%Y-%m-%d)"
-          git pull --rebase && git push
+          git pull --rebase --autostash && git push

--- a/.github/workflows/submit-benchmark-iqm.yml
+++ b/.github/workflows/submit-benchmark-iqm.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit IQM benchmark $(date -u +%Y-%m-%d)"
-          git pull --rebase && git push
+          git pull --rebase --autostash && git push

--- a/.github/workflows/submit-benchmark.yml
+++ b/.github/workflows/submit-benchmark.yml
@@ -71,4 +71,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pending/
           git diff --staged --quiet || git commit -m "chore: submit benchmark $(date -u +%Y-%m-%d)"
-          git pull --rebase && git push
+          git pull --rebase --autostash && git push


### PR DESCRIPTION
Adds --autostash so uv.lock modifications don't block the rebase.