### PR TITLE
Fix collect workflow: add IBM credentials

### DIFF
--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -58,6 +58,8 @@ jobs:
           BRAKET_RESULTS_BUCKET_EAST: ${{ vars.BRAKET_RESULTS_BUCKET_EAST }}
           BRAKET_RESULTS_BUCKET_EU: ${{ vars.BRAKET_RESULTS_BUCKET_EU }}
           AQT_API_KEY: ${{ secrets.AQT_API_KEY }}
+          IBM_QUANTUM_TOKEN: ${{ secrets.IBM_QUANTUM_TOKEN }}
+          IBM_QUANTUM_INSTANCE: ${{ vars.IBM_QUANTUM_INSTANCE }}
         run: uv run python scripts/collect_results.py
 
       - name: Commit results


### PR DESCRIPTION
IBM_QUANTUM_TOKEN and IBM_QUANTUM_INSTANCE were missing from collect-results.yml, causing IBM job collection to fail.